### PR TITLE
v2.4.0: sync parity + colorless job verbs, and dataset snapshot error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Bright Data Python SDK Changelog
 
-## Unreleased - Sync parity + colorless job verbs
+## Version 2.4.0 - Sync parity, colorless job verbs, dataset error reporting
 
 - **Sync client parity**: `SyncBrightDataClient` now mirrors the async surface. Added `client.datasets` (fixes the `SyncBrightDataClient` `datasets` `AttributeError`), the 5 missing scrapers (`scrape.tiktok` / `youtube` / `reddit` / `perplexity` / `digikey`), the 2 missing search verticals (`search.tiktok` / `youtube`), Pinterest trigger/status/fetch, and Instagram-search `profiles` / `reels_all`.
 - **Service-level job verbs (colorless pattern)**: every scraper now exposes generic `status` / `wait` / `fetch` / `to_result(snapshot_id)` (on `BaseWebScraper`), and `DiscoverService` gained `status` / `wait` / `fetch` / `to_result(task_id)` — so a triggered job can be driven by its id alone, like the crawler. Purely additive; the existing `job.fetch()` etc. are unchanged.
 - **Discover sync manual path (new)**: `SyncBrightDataClient` adds `discover_status` / `discover_wait` / `discover_fetch` / `discover_to_result(task_id)`, and a colorless `DiscoverSnapshot` handle.
 - **Contract change**: sync `discover_trigger()` now returns a `DiscoverSnapshot` (a typed, drivable handle) instead of the async-only `DiscoverJob` (which could not be used from sync). Migration: poll via `client.discover_status(snap.task_id)` / `client.discover_fetch(snap.task_id)`.
+- **Fixed**: failed dataset snapshots now expose the API failure reason — and, when no recognized reason key is present, the raw snapshot status response as a fallback — plus the `snapshot_id`, instead of the unhelpful `DatasetError: Snapshot failed: None`. `SnapshotStatus` now retains the full API response (`.raw`) and matches more reason keys (`error` / `error_message` / `message` / `failure_reason`). The synchronous path inherits the fix.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Bright Data Python SDK Changelog
 
+## Unreleased - Sync parity + colorless job verbs
+
+- **Sync client parity**: `SyncBrightDataClient` now mirrors the async surface. Added `client.datasets` (fixes the `SyncBrightDataClient` `datasets` `AttributeError`), the 5 missing scrapers (`scrape.tiktok` / `youtube` / `reddit` / `perplexity` / `digikey`), the 2 missing search verticals (`search.tiktok` / `youtube`), Pinterest trigger/status/fetch, and Instagram-search `profiles` / `reels_all`.
+- **Service-level job verbs (colorless pattern)**: every scraper now exposes generic `status` / `wait` / `fetch` / `to_result(snapshot_id)` (on `BaseWebScraper`), and `DiscoverService` gained `status` / `wait` / `fetch` / `to_result(task_id)` — so a triggered job can be driven by its id alone, like the crawler. Purely additive; the existing `job.fetch()` etc. are unchanged.
+- **Discover sync manual path (new)**: `SyncBrightDataClient` adds `discover_status` / `discover_wait` / `discover_fetch` / `discover_to_result(task_id)`, and a colorless `DiscoverSnapshot` handle.
+- **Contract change**: sync `discover_trigger()` now returns a `DiscoverSnapshot` (a typed, drivable handle) instead of the async-only `DiscoverJob` (which could not be used from sync). Migration: poll via `client.discover_status(snap.task_id)` / `client.discover_fetch(snap.task_id)`.
+
+---
+
 ## Version 2.3.0 - Browser API, Scraper Studio, 175 Datasets
 
 - **Browser API**: Connect to cloud Chrome via CDP WebSocket. SDK builds the `wss://` URL, you connect with Playwright/Puppeteer (`client.browser.get_connect_url()`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "brightdata-sdk"
-version = "2.3.2"
+version = "2.4.0"
 description = "Modern async-first Python SDK for Bright Data APIs"
 authors = [{name = "Bright Data", email = "support@brightdata.com"}]
 license = {text = "MIT"}

--- a/src/brightdata/__init__.py
+++ b/src/brightdata/__init__.py
@@ -27,7 +27,7 @@ from .models import (
 from .scrapers.job import ScrapeJob
 
 # Export Discover API models
-from .discover.models import DiscoverResult, DiscoverJob
+from .discover.models import DiscoverResult, DiscoverJob, DiscoverSnapshot
 
 # Export payload models (dataclasses)
 from .payloads import (
@@ -137,6 +137,7 @@ __all__ = [
     # Discover API
     "DiscoverResult",
     "DiscoverJob",
+    "DiscoverSnapshot",
     # Services
     "WebUnlockerService",
     "BrowserService",

--- a/src/brightdata/datasets/base.py
+++ b/src/brightdata/datasets/base.py
@@ -102,7 +102,9 @@ class BaseDataset:
             data = await response.json()
 
         if "snapshot_id" not in data:
-            error_msg = data.get("error") or data.get("message") or str(data)
+            error_msg = (
+                data.get("error") or data.get("message") or data.get("failure_reason") or str(data)
+            )
             raise DatasetError(f"Failed to create snapshot: {error_msg}")
 
         return data["snapshot_id"]
@@ -180,11 +182,12 @@ class BaseDataset:
             if status.status == "ready":
                 break
             elif status.status == "failed":
-                raise DatasetError(f"Snapshot failed: {status.error}")
+                reason = status.error or status.raw or "no reason returned by API"
+                raise DatasetError(f"Snapshot {snapshot_id} failed: {reason}")
             elif time.time() - start_time > timeout:
                 raise TimeoutError(
                     f"Snapshot {snapshot_id} not ready after {timeout}s "
-                    f"(status: {status.status})"
+                    f"(status: {status.status}, last_response: {status.raw})"
                 )
 
             await asyncio.sleep(poll_interval)

--- a/src/brightdata/datasets/models.py
+++ b/src/brightdata/datasets/models.py
@@ -58,6 +58,7 @@ class SnapshotStatus:
     file_size: Optional[int] = None  # bytes
     cost: Optional[float] = None
     error: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)  # full API response — never lose the reason
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SnapshotStatus":
@@ -69,5 +70,11 @@ class SnapshotStatus:
             dataset_size=data.get("dataset_size"),
             file_size=data.get("file_size"),
             cost=data.get("cost"),
-            error=data.get("error", data.get("error_message")),
+            error=(
+                data.get("error")
+                or data.get("error_message")
+                or data.get("message")
+                or data.get("failure_reason")
+            ),
+            raw=data,
         )

--- a/src/brightdata/discover/models.py
+++ b/src/brightdata/discover/models.py
@@ -46,6 +46,30 @@ class DiscoverResult(BaseResult):
 
 
 @dataclass
+class DiscoverSnapshot:
+    """
+    Colorless handle for a triggered Discover search — data only, no I/O methods.
+
+    Mirrors the crawler's CrawlJob shape: the verbs live on the service, not the
+    handle. Returned by the sync client's ``discover_trigger()``; poll/fetch via
+    ``discover_status`` / ``discover_wait`` / ``discover_fetch`` / ``discover_to_result``
+    (by ``task_id``), or the async ``DiscoverService`` verbs.
+
+    Attributes:
+        task_id: Discover API task identifier.
+        query: Original search query (echo).
+        intent: Intent used for ranking (echo).
+    """
+
+    task_id: str
+    query: str = ""
+    intent: Optional[str] = None
+
+    def __repr__(self) -> str:
+        return f"<DiscoverSnapshot task_id={self.task_id[:16]}...>"
+
+
+@dataclass
 class DiscoverJob:
     """
     Handle for a pending Discover API search.

--- a/src/brightdata/discover/service.py
+++ b/src/brightdata/discover/service.py
@@ -160,6 +160,62 @@ class DiscoverService:
             intent=intent,
         )
 
+    # ------------------------------------------------------------------
+    # PUBLIC SERVICE VERBS (drive a discover task by task_id)
+    # ------------------------------------------------------------------
+    # Discover was the one subsystem lacking id-based status/fetch on the
+    # service (it had only the DiscoverJob methods). These are additive and
+    # mirror DiscoverJob.status/fetch/wait/to_result, keyed by task_id, so a
+    # caller can poll/fetch a triggered search with only its task_id.
+
+    async def status(self, task_id: str) -> str:
+        """Check a discover task's status by task_id ('processing' or 'done')."""
+        response_data = await self._poll_once(task_id)
+        return response_data.get("status", "processing")
+
+    async def fetch(self, task_id: str) -> List[Dict[str, Any]]:
+        """Fetch a discover task's results by task_id. Call after status == 'done'."""
+        response_data = await self._poll_once(task_id)
+        return response_data.get("results", [])
+
+    async def wait(self, task_id: str, timeout: int = 60, poll_interval: int = 2) -> str:
+        """Poll a discover task until done (or fail/timeout), by task_id."""
+        await self._poll_until_done(task_id, timeout, poll_interval)
+        return "done"
+
+    async def to_result(
+        self, task_id: str, timeout: int = 60, poll_interval: int = 2
+    ) -> DiscoverResult:
+        """
+        Wait + fetch + wrap a discover task (by task_id) as DiscoverResult.
+
+        Note: query/intent are not recoverable from a bare task_id, so they are
+        left empty here; use DiscoverJob.to_result() (or the service's search())
+        when you need them populated.
+        """
+        trigger_time = datetime.now(timezone.utc)
+        try:
+            response_data = await self._poll_until_done(task_id, timeout, poll_interval)
+            fetch_time = datetime.now(timezone.utc)
+            results = response_data.get("results", [])
+            return DiscoverResult(
+                success=True,
+                data=results,
+                duration_seconds=response_data.get("duration_seconds"),
+                total_results=len(results),
+                task_id=task_id,
+                trigger_sent_at=trigger_time,
+                data_fetched_at=fetch_time,
+            )
+        except Exception as e:
+            return DiscoverResult(
+                success=False,
+                error=str(e),
+                task_id=task_id,
+                trigger_sent_at=trigger_time,
+                data_fetched_at=datetime.now(timezone.utc),
+            )
+
     async def _trigger(
         self,
         query: str,

--- a/src/brightdata/scrapers/base.py
+++ b/src/brightdata/scrapers/base.py
@@ -11,8 +11,10 @@ Philosophy:
 
 import asyncio
 import os
+import time
 import concurrent.futures
 from abc import ABC
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Union
 
 from ..core.engine import AsyncEngine
@@ -355,6 +357,137 @@ class BaseWebScraper(ABC):
     def _fetch_results(self, snapshot_id: str, format: str = "json") -> Any:
         """Fetch scrape job results (internal sync wrapper)."""
         return _run_blocking(self._fetch_results_async(snapshot_id, format=format))
+
+    # ============================================================================
+    # PUBLIC SERVICE VERBS (drive a triggered job by snapshot_id)
+    # ============================================================================
+    # These let any triggered scrape be polled/fetched from the service, given
+    # only its snapshot_id — the "colorless job" pattern the crawler already uses
+    # (CrawlJob is data; CrawlerService.status/download own the verbs). They are
+    # purely additive: the same logic that ScrapeJob.status/wait/fetch/to_result
+    # run, exposed on the service so a plain snapshot_id (or a future colorless
+    # snapshot) is all a caller needs.
+
+    async def status(self, snapshot_id: str) -> str:
+        """
+        Check a triggered job's status by snapshot_id.
+
+        Returns:
+            Status string: "ready", "in_progress", "error", etc.
+
+        Example:
+            >>> sid = (await scraper.products_trigger(url)).snapshot_id
+            >>> s = await scraper.status(sid)
+        """
+        return await self._check_status_async(snapshot_id)
+
+    async def wait(
+        self,
+        snapshot_id: str,
+        timeout: Optional[int] = None,
+        poll_interval: int = DEFAULT_POLL_INTERVAL,
+        verbose: bool = False,
+    ) -> str:
+        """
+        Poll a triggered job until it is ready (by snapshot_id).
+
+        Args:
+            snapshot_id: Snapshot identifier from a trigger operation.
+            timeout: Maximum seconds to wait (uses MIN_POLL_TIMEOUT if None).
+            poll_interval: Seconds between status checks.
+            verbose: Print status updates.
+
+        Returns:
+            Final status ("ready").
+
+        Raises:
+            TimeoutError: If timeout is reached.
+            APIError: If the job fails.
+        """
+        wait_timeout = timeout or self.MIN_POLL_TIMEOUT
+        start_time = time.time()
+
+        while True:
+            elapsed = time.time() - start_time
+            if elapsed > wait_timeout:
+                raise TimeoutError(f"Job {snapshot_id} timed out after {wait_timeout}s")
+
+            current = await self.status(snapshot_id)
+
+            if verbose:
+                print(f"   [{elapsed:.1f}s] Job status: {current}")
+
+            if current == "ready":
+                return current
+            elif current == "error" or current == "failed":
+                raise APIError(f"Job {snapshot_id} failed with status: {current}")
+
+            await asyncio.sleep(poll_interval)
+
+    async def fetch(self, snapshot_id: str, format: str = "json") -> Any:
+        """
+        Fetch a triggered job's results by snapshot_id.
+
+        Note: Does not check readiness. Use wait() first or check status().
+
+        Args:
+            snapshot_id: Snapshot identifier from a trigger operation.
+            format: Result format ("json" or "raw").
+
+        Returns:
+            The job results.
+        """
+        return await self._fetch_results_async(snapshot_id, format=format)
+
+    async def to_result(
+        self,
+        snapshot_id: str,
+        timeout: Optional[int] = None,
+        poll_interval: int = DEFAULT_POLL_INTERVAL,
+    ) -> ScrapeResult:
+        """
+        Wait for a triggered job to complete, fetch it, and wrap in a ScrapeResult.
+
+        Convenience that combines wait() + fetch() + result construction, by
+        snapshot_id. Cost/timing are derived from the service's own
+        PLATFORM_NAME / COST_PER_RECORD, so nothing is needed beyond the id.
+
+        Args:
+            snapshot_id: Snapshot identifier from a trigger operation.
+            timeout: Maximum seconds to wait (uses MIN_POLL_TIMEOUT if None).
+            poll_interval: Seconds between status checks.
+
+        Returns:
+            ScrapeResult (success or, on failure, success=False with error set).
+        """
+        start_time = datetime.now(timezone.utc)
+
+        try:
+            await self.wait(snapshot_id, timeout=timeout, poll_interval=poll_interval)
+            data = await self.fetch(snapshot_id)
+            end_time = datetime.now(timezone.utc)
+
+            record_count = len(data) if isinstance(data, list) else 1
+            estimated_cost = record_count * self.COST_PER_RECORD
+
+            return ScrapeResult(
+                success=True,
+                data=data,
+                platform=self.PLATFORM_NAME or None,
+                cost=estimated_cost,
+                snapshot_id=snapshot_id,
+                trigger_sent_at=start_time,
+                data_fetched_at=end_time,
+            )
+        except Exception as e:
+            return ScrapeResult(
+                success=False,
+                error=str(e),
+                platform=self.PLATFORM_NAME or None,
+                snapshot_id=snapshot_id,
+                trigger_sent_at=start_time,
+                data_fetched_at=datetime.now(timezone.utc),
+            )
 
     # ============================================================================
     # CONTEXT MANAGER SUPPORT (for standalone usage)

--- a/src/brightdata/sync_client.py
+++ b/src/brightdata/sync_client.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 from .client import BrightDataClient
 from .browser.service import BrowserService
 from .models import ScrapeResult, SearchResult
-from .discover.models import DiscoverResult, DiscoverJob
+from .discover.models import DiscoverResult, DiscoverSnapshot
 from .types import AccountInfo
 
 
@@ -106,6 +106,7 @@ class SyncBrightDataClient:
         self._search: Optional["SyncSearchService"] = None
         self._crawler: Optional["SyncCrawlerService"] = None
         self._scraper_studio: Optional["SyncScraperStudioService"] = None
+        self._datasets: Optional["SyncDatasetsClient"] = None
 
     def __enter__(self):
         """Initialize persistent event loop and async client."""
@@ -195,9 +196,45 @@ class SyncBrightDataClient:
         """Search the web with AI-powered relevance ranking."""
         return self._run(self._async_client.discover(query, **kwargs))
 
-    def discover_trigger(self, query: str, **kwargs) -> DiscoverJob:
-        """Trigger a discover search, return job for manual polling."""
-        return self._run(self._async_client.discover_trigger(query, **kwargs))
+    def discover_trigger(self, query: str, **kwargs) -> DiscoverSnapshot:
+        """Trigger a discover search; returns a colorless DiscoverSnapshot.
+
+        Poll/fetch with discover_status / discover_wait / discover_fetch /
+        discover_to_result (by task_id). (Previously returned the async-only
+        DiscoverJob, which could not be driven from sync.)
+        """
+        job = self._run(self._async_client.discover_trigger(query, **kwargs))
+        return DiscoverSnapshot(
+            task_id=job.task_id,
+            query=getattr(job, "query", "") or "",
+            intent=getattr(job, "intent", None),
+        )
+
+    def _discover_service(self):
+        """The async DiscoverService, ensured to exist (lazy, same as the async client)."""
+        svc = self._async_client._discover_service
+        if svc is None:
+            from .discover.service import DiscoverService
+
+            svc = DiscoverService(self._async_client.engine)
+            self._async_client._discover_service = svc
+        return svc
+
+    def discover_status(self, task_id: str) -> str:
+        """Check a triggered discover search's status by task_id ('processing'/'done')."""
+        return self._run(self._discover_service().status(task_id))
+
+    def discover_wait(self, task_id: str, **kwargs) -> str:
+        """Poll a triggered discover search until done, by task_id."""
+        return self._run(self._discover_service().wait(task_id, **kwargs))
+
+    def discover_fetch(self, task_id: str):
+        """Fetch a triggered discover search's results by task_id."""
+        return self._run(self._discover_service().fetch(task_id))
+
+    def discover_to_result(self, task_id: str, **kwargs) -> DiscoverResult:
+        """Wait + fetch + wrap a triggered discover search as DiscoverResult, by task_id."""
+        return self._run(self._discover_service().to_result(task_id, **kwargs))
 
     # ========================================
     # Service Properties
@@ -214,6 +251,13 @@ class SyncBrightDataClient:
         if self._scrape is None:
             self._scrape = SyncScrapeService(self._async_client.scrape, self._loop)
         return self._scrape
+
+    @property
+    def datasets(self) -> "SyncDatasetsClient":
+        """Access pre-collected datasets (sync)."""
+        if self._datasets is None:
+            self._datasets = SyncDatasetsClient(self._async_client.datasets, self._loop)
+        return self._datasets
 
     @property
     def search(self) -> "SyncSearchService":
@@ -266,6 +310,12 @@ class SyncScrapeService:
         self._instagram = None
         self._facebook = None
         self._chatgpt = None
+        self._pinterest = None
+        self._tiktok = None
+        self._youtube = None
+        self._reddit = None
+        self._perplexity = None
+        self._digikey = None
 
     @property
     def amazon(self) -> "SyncAmazonScraper":
@@ -299,9 +349,39 @@ class SyncScrapeService:
 
     @property
     def pinterest(self) -> "SyncPinterestScraper":
-        if not hasattr(self, "_pinterest") or self._pinterest is None:
+        if self._pinterest is None:
             self._pinterest = SyncPinterestScraper(self._async.pinterest, self._loop)
         return self._pinterest
+
+    @property
+    def tiktok(self) -> "SyncTikTokScraper":
+        if self._tiktok is None:
+            self._tiktok = SyncTikTokScraper(self._async.tiktok, self._loop)
+        return self._tiktok
+
+    @property
+    def youtube(self) -> "SyncYouTubeScraper":
+        if self._youtube is None:
+            self._youtube = SyncYouTubeScraper(self._async.youtube, self._loop)
+        return self._youtube
+
+    @property
+    def reddit(self) -> "SyncRedditScraper":
+        if self._reddit is None:
+            self._reddit = SyncRedditScraper(self._async.reddit, self._loop)
+        return self._reddit
+
+    @property
+    def perplexity(self) -> "SyncPerplexityScraper":
+        if self._perplexity is None:
+            self._perplexity = SyncPerplexityScraper(self._async.perplexity, self._loop)
+        return self._perplexity
+
+    @property
+    def digikey(self) -> "SyncDigiKeyScraper":
+        if self._digikey is None:
+            self._digikey = SyncDigiKeyScraper(self._async.digikey, self._loop)
+        return self._digikey
 
 
 class SyncAmazonScraper:
@@ -592,6 +672,207 @@ class SyncChatGPTScraper:
         return self._loop.run_until_complete(self._async.prompts_fetch(snapshot_id))
 
 
+class SyncTikTokScraper:
+    """Sync wrapper for TikTokScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    # Profiles
+    def profiles(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles(*args, **kwargs))
+
+    def profiles_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles_trigger(*args, **kwargs))
+
+    def profiles_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_status(snapshot_id))
+
+    def profiles_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_fetch(snapshot_id))
+
+    # Posts
+    def posts(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts(*args, **kwargs))
+
+    def posts_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_trigger(*args, **kwargs))
+
+    def posts_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_status(snapshot_id))
+
+    def posts_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_fetch(snapshot_id))
+
+    # Comments
+    def comments(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.comments(*args, **kwargs))
+
+    def comments_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.comments_trigger(*args, **kwargs))
+
+    def comments_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.comments_status(snapshot_id))
+
+    def comments_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.comments_fetch(snapshot_id))
+
+    # Fast API variants
+    def posts_by_profile_fast(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_profile_fast(*args, **kwargs))
+
+    def posts_by_url_fast(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_url_fast(*args, **kwargs))
+
+    def posts_by_search_url_fast(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_search_url_fast(*args, **kwargs))
+
+
+class SyncYouTubeScraper:
+    """Sync wrapper for YouTubeScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    # Videos
+    def videos(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos(*args, **kwargs))
+
+    def videos_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos_trigger(*args, **kwargs))
+
+    def videos_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.videos_status(snapshot_id))
+
+    def videos_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.videos_fetch(snapshot_id))
+
+    # Channels
+    def channels(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.channels(*args, **kwargs))
+
+    def channels_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.channels_trigger(*args, **kwargs))
+
+    def channels_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.channels_status(snapshot_id))
+
+    def channels_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.channels_fetch(snapshot_id))
+
+    # Comments
+    def comments(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.comments(*args, **kwargs))
+
+    def comments_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.comments_trigger(*args, **kwargs))
+
+    def comments_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.comments_status(snapshot_id))
+
+    def comments_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.comments_fetch(snapshot_id))
+
+
+class SyncRedditScraper:
+    """Sync wrapper for RedditScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    # Posts
+    def posts(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts(*args, **kwargs))
+
+    def posts_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_trigger(*args, **kwargs))
+
+    def posts_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_status(snapshot_id))
+
+    def posts_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_fetch(snapshot_id))
+
+    # Comments
+    def comments(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.comments(*args, **kwargs))
+
+    def comments_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.comments_trigger(*args, **kwargs))
+
+    def comments_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.comments_status(snapshot_id))
+
+    def comments_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.comments_fetch(snapshot_id))
+
+    # Discovery
+    def posts_by_keyword(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_keyword(*args, **kwargs))
+
+    def posts_by_subreddit(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_subreddit(*args, **kwargs))
+
+
+class SyncPerplexityScraper:
+    """Sync wrapper for PerplexityScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    def search(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.search(*args, **kwargs))
+
+    def search_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.search_trigger(*args, **kwargs))
+
+    def search_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.search_status(snapshot_id))
+
+    def search_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.search_fetch(snapshot_id))
+
+
+class SyncDigiKeyScraper:
+    """Sync wrapper for DigiKeyScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    # Products
+    def products(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.products(*args, **kwargs))
+
+    def products_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.products_trigger(*args, **kwargs))
+
+    def products_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.products_status(snapshot_id))
+
+    def products_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.products_fetch(snapshot_id))
+
+    # Discover by category
+    def discover_by_category(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.discover_by_category(*args, **kwargs))
+
+    def discover_by_category_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(
+            self._async.discover_by_category_trigger(*args, **kwargs)
+        )
+
+    def discover_by_category_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.discover_by_category_status(snapshot_id))
+
+    def discover_by_category_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.discover_by_category_fetch(snapshot_id))
+
+
 # ============================================================================
 # SYNC SEARCH SERVICE
 # ============================================================================
@@ -606,6 +887,9 @@ class SyncSearchService:
         self._amazon = None
         self._linkedin = None
         self._instagram = None
+        self._pinterest = None
+        self._tiktok = None
+        self._youtube = None
 
     def google(self, query, **kwargs) -> SearchResult:
         """Search Google."""
@@ -648,9 +932,23 @@ class SyncSearchService:
     @property
     def pinterest(self) -> "SyncPinterestSearchScraper":
         """Pinterest search service."""
-        if not hasattr(self, "_pinterest") or self._pinterest is None:
+        if self._pinterest is None:
             self._pinterest = SyncPinterestSearchScraper(self._async.pinterest, self._loop)
         return self._pinterest
+
+    @property
+    def tiktok(self) -> "SyncTikTokSearchScraper":
+        """TikTok search service."""
+        if self._tiktok is None:
+            self._tiktok = SyncTikTokSearchScraper(self._async.tiktok, self._loop)
+        return self._tiktok
+
+    @property
+    def youtube(self) -> "SyncYouTubeSearchScraper":
+        """YouTube search service."""
+        if self._youtube is None:
+            self._youtube = SyncYouTubeSearchScraper(self._async.youtube, self._loop)
+        return self._youtube
 
 
 class SyncAmazonSearchScraper:
@@ -694,6 +992,12 @@ class SyncInstagramSearchScraper:
     def reels(self, url, **kwargs):
         return self._loop.run_until_complete(self._async.reels(url, **kwargs))
 
+    def profiles(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles(*args, **kwargs))
+
+    def reels_all(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.reels_all(*args, **kwargs))
+
 
 class SyncChatGPTSearchService:
     """Sync wrapper for ChatGPTSearchService."""
@@ -717,8 +1021,26 @@ class SyncPinterestScraper:
     def posts(self, url, **kwargs):
         return self._loop.run_until_complete(self._async.posts(url, **kwargs))
 
+    def posts_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_trigger(*args, **kwargs))
+
+    def posts_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_status(snapshot_id))
+
+    def posts_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_fetch(snapshot_id))
+
     def profiles(self, url, **kwargs):
         return self._loop.run_until_complete(self._async.profiles(url, **kwargs))
+
+    def profiles_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles_trigger(*args, **kwargs))
+
+    def profiles_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_status(snapshot_id))
+
+    def profiles_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_fetch(snapshot_id))
 
 
 class SyncPinterestSearchScraper:
@@ -736,6 +1058,52 @@ class SyncPinterestSearchScraper:
 
     def profiles(self, keyword, **kwargs):
         return self._loop.run_until_complete(self._async.profiles(keyword, **kwargs))
+
+
+class SyncTikTokSearchScraper:
+    """Sync wrapper for TikTokSearchScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    def profiles(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles(*args, **kwargs))
+
+    def posts_by_keyword(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_keyword(*args, **kwargs))
+
+    def posts_by_profile(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_profile(*args, **kwargs))
+
+    def posts_by_url(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_url(*args, **kwargs))
+
+
+class SyncYouTubeSearchScraper:
+    """Sync wrapper for YouTubeSearchScraper."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    def videos_by_keyword(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos_by_keyword(*args, **kwargs))
+
+    def videos_by_hashtag(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos_by_hashtag(*args, **kwargs))
+
+    def videos_by_channel(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos_by_channel(*args, **kwargs))
+
+    def videos_by_explore(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos_by_explore(*args, **kwargs))
+
+    def videos_by_search_filters(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.videos_by_search_filters(*args, **kwargs))
+
+    def channels_by_keyword(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.channels_by_keyword(*args, **kwargs))
 
 
 # ============================================================================
@@ -796,3 +1164,64 @@ class SyncScraperStudioService:
     def fetch(self, response_id):
         """Fetch results."""
         return self._loop.run_until_complete(self._async.fetch(response_id))
+
+
+# ============================================================================
+# SYNC DATASETS CLIENT
+# ============================================================================
+
+
+class SyncDatasetsClient:
+    """Sync wrapper for DatasetsClient — access pre-collected datasets.
+
+    Mirrors the async DatasetsClient: ``list()`` plus dynamic dataset access
+    via ``__getattr__`` (e.g. ``client.datasets.imdb_movies``), each returning
+    a SyncDataset.
+    """
+
+    def __init__(self, async_datasets, loop):
+        self._async = async_datasets
+        self._loop = loop
+        self._cache: dict = {}
+
+    def list(self):
+        """List all available datasets."""
+        return self._loop.run_until_complete(self._async.list())
+
+    def __getattr__(self, name):
+        # Guard: never recurse for private/dunder attrs (e.g. during init/copy).
+        if name.startswith("_"):
+            raise AttributeError(name)
+        if name not in self._cache:
+            # getattr on the async client triggers its registry import + instantiation;
+            # raises AttributeError with the available-datasets list for unknown names.
+            self._cache[name] = SyncDataset(getattr(self._async, name), self._loop)
+        return self._cache[name]
+
+
+class SyncDataset:
+    """Sync wrapper for a single dataset (BaseDataset)."""
+
+    def __init__(self, async_dataset, loop):
+        self._async = async_dataset
+        self._loop = loop
+
+    def __call__(self, *args, **kwargs):
+        """Filter the dataset and create a snapshot — returns snapshot_id."""
+        return self._loop.run_until_complete(self._async(*args, **kwargs))
+
+    def download(self, snapshot_id, **kwargs):
+        """Poll until ready, then download snapshot data."""
+        return self._loop.run_until_complete(self._async.download(snapshot_id, **kwargs))
+
+    def get_status(self, snapshot_id):
+        """Check snapshot status."""
+        return self._loop.run_until_complete(self._async.get_status(snapshot_id))
+
+    def sample(self, records_limit=10):
+        """Get a sample of records without specifying a filter."""
+        return self._loop.run_until_complete(self._async.sample(records_limit=records_limit))
+
+    def get_metadata(self):
+        """Get the dataset's field schema."""
+        return self._loop.run_until_complete(self._async.get_metadata())

--- a/tests/unit/test_colorless_service_verbs.py
+++ b/tests/unit/test_colorless_service_verbs.py
@@ -1,0 +1,175 @@
+"""
+Tests for the colorless-job service verbs (slice 1 of the colorless refactor).
+
+Covers the additive service-level verbs that let a triggered job be driven by
+its id alone:
+  - BaseWebScraper.status / wait / fetch / to_result(snapshot_id)
+  - DiscoverService.status / wait / fetch / to_result(task_id)
+
+Also guards that the existing colored ScrapeJob methods still work (no
+regression) and that the relocated logic matches the job's behavior.
+
+Mocked at the api_client / _poll_once seam (not raw aiohttp), per the plan.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from brightdata.scrapers.amazon import AmazonScraper
+from brightdata.scrapers.job import ScrapeJob
+from brightdata.discover.service import DiscoverService
+from brightdata.models import ScrapeResult
+from brightdata.discover.models import DiscoverResult
+from brightdata.exceptions import APIError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scraper_with_api(api):
+    """An AmazonScraper (concrete BaseWebScraper) with its api_client mocked."""
+    s = AmazonScraper(bearer_token="x" * 12)
+    s.api_client = api
+    return s
+
+
+def _api(status="ready", data=None, status_seq=None):
+    api = AsyncMock()
+    if status_seq is not None:
+        api.get_status.side_effect = list(status_seq)
+    else:
+        api.get_status.return_value = status
+    api.fetch_result.return_value = data if data is not None else [{"k": 1}]
+    return api
+
+
+# ---------------------------------------------------------------------------
+# BaseWebScraper service verbs (inherited by every scraper)
+# ---------------------------------------------------------------------------
+
+
+class TestScraperServiceVerbs:
+    @pytest.mark.asyncio
+    async def test_status_delegates_to_api_client(self):
+        s = _scraper_with_api(_api(status="running"))
+        assert await s.status("snap_1") == "running"
+        s.api_client.get_status.assert_awaited_once_with("snap_1")
+
+    @pytest.mark.asyncio
+    async def test_fetch_delegates_to_api_client(self):
+        s = _scraper_with_api(_api(data=[{"a": 1}, {"b": 2}]))
+        assert await s.fetch("snap_1") == [{"a": 1}, {"b": 2}]
+        s.api_client.fetch_result.assert_awaited_once_with("snap_1", format="json")
+
+    @pytest.mark.asyncio
+    async def test_wait_polls_until_ready(self):
+        s = _scraper_with_api(_api(status_seq=["running", "running", "ready"]))
+        assert await s.wait("snap_1", poll_interval=0) == "ready"
+        assert s.api_client.get_status.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_wait_raises_on_failed_status(self):
+        s = _scraper_with_api(_api(status="failed"))
+        with pytest.raises(APIError):
+            await s.wait("snap_1", poll_interval=0)
+
+    @pytest.mark.asyncio
+    async def test_wait_times_out(self):
+        s = _scraper_with_api(_api(status="running"))
+        with pytest.raises(TimeoutError):
+            await s.wait("snap_1", timeout=-1, poll_interval=0)
+
+    @pytest.mark.asyncio
+    async def test_to_result_success(self):
+        s = _scraper_with_api(_api(status="ready", data=[{"a": 1}, {"b": 2}]))
+        res = await s.to_result("snap_1", poll_interval=0)
+        assert isinstance(res, ScrapeResult)
+        assert res.success is True
+        assert res.data == [{"a": 1}, {"b": 2}]
+        assert res.snapshot_id == "snap_1"
+        assert res.platform == (s.PLATFORM_NAME or None)
+        assert res.cost == 2 * s.COST_PER_RECORD  # cost from the service's class attrs
+
+    @pytest.mark.asyncio
+    async def test_to_result_failure_is_caught(self):
+        s = _scraper_with_api(_api(status="error"))
+        res = await s.to_result("snap_1", poll_interval=0)
+        assert res.success is False
+        assert res.error and "error" in res.error.lower()
+        assert res.snapshot_id == "snap_1"
+
+
+# ---------------------------------------------------------------------------
+# Parity + regression: the colored ScrapeJob still works, and the relocated
+# service verbs produce the same result as the job's methods.
+# ---------------------------------------------------------------------------
+
+
+class TestParityAndRegression:
+    @pytest.mark.asyncio
+    async def test_scrapejob_methods_still_work(self):
+        api = _api(status="ready", data=[{"z": 9}])
+        job = ScrapeJob(snapshot_id="snap_1", api_client=api)
+        assert await job.status() == "ready"
+        assert await job.fetch() == [{"z": 9}]
+
+    @pytest.mark.asyncio
+    async def test_service_verb_matches_job(self):
+        api = _api(status="ready", data=[{"x": 1}])
+        s = _scraper_with_api(api)
+        job = ScrapeJob(snapshot_id="snap_1", api_client=api)
+        assert await s.fetch("snap_1") == await job.fetch()
+        assert await s.status("snap_1") == await job.status()
+
+
+# ---------------------------------------------------------------------------
+# DiscoverService service verbs (the previously-missing id-based path)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverServiceVerbs:
+    def _svc(self):
+        return DiscoverService(engine=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_status_by_task_id(self):
+        svc = self._svc()
+        svc._poll_once = AsyncMock(return_value={"status": "done", "results": []})
+        assert await svc.status("t1") == "done"
+        svc._poll_once.assert_awaited_once_with("t1")
+
+    @pytest.mark.asyncio
+    async def test_fetch_by_task_id(self):
+        svc = self._svc()
+        svc._poll_once = AsyncMock(return_value={"status": "done", "results": [{"r": 1}]})
+        assert await svc.fetch("t1") == [{"r": 1}]
+
+    @pytest.mark.asyncio
+    async def test_wait_by_task_id(self):
+        svc = self._svc()
+        svc._poll_until_done = AsyncMock(return_value={"status": "done", "results": []})
+        assert await svc.wait("t1") == "done"
+        svc._poll_until_done.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_to_result_by_task_id(self):
+        svc = self._svc()
+        svc._poll_until_done = AsyncMock(
+            return_value={"status": "done", "results": [{"r": 1}], "duration_seconds": 1.2}
+        )
+        res = await svc.to_result("t1")
+        assert isinstance(res, DiscoverResult)
+        assert res.success is True
+        assert res.total_results == 1
+        assert res.task_id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_to_result_failure_is_caught(self):
+        svc = self._svc()
+        svc._poll_until_done = AsyncMock(side_effect=APIError("Discover task failed: boom"))
+        res = await svc.to_result("t1")
+        assert res.success is False
+        assert res.task_id == "t1"
+        assert res.error and "boom" in res.error

--- a/tests/unit/test_datasets_error_reporting.py
+++ b/tests/unit/test_datasets_error_reporting.py
@@ -1,0 +1,88 @@
+"""
+Tests for dataset snapshot error reporting (Issue 2 — devdocs/scoped/2/).
+
+A failed snapshot must expose the API failure reason (or, when no recognized
+reason key is present, the raw status response as a fallback) plus the
+snapshot_id — never the unhelpful literal "Snapshot failed: None".
+
+Mocked at the boundary (get_status is patched) so no network is involved.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from brightdata.datasets.base import BaseDataset, DatasetError
+from brightdata.datasets.models import SnapshotStatus
+
+
+class _Dataset(BaseDataset):
+    """Concrete dataset for tests (leading underscore → not collected by pytest)."""
+
+    DATASET_ID = "gd_test"
+    NAME = "test"
+
+
+def _dataset() -> _Dataset:
+    # The engine is never used in these tests (get_status is patched), but
+    # BaseDataset stores it at construction.
+    return _Dataset(engine=MagicMock())
+
+
+class TestSnapshotStatusParsing:
+    def test_reason_under_non_error_key_is_captured(self):
+        data = {"status": "failed", "snapshot_id": "s1", "message": "quota exceeded"}
+        status = SnapshotStatus.from_dict(data)
+        assert status.status == "failed"
+        assert status.error == "quota exceeded"
+        assert status.raw == data  # full response retained, not just 7 named fields
+
+    def test_failure_reason_key_is_captured(self):
+        data = {"status": "failed", "id": "s2", "failure_reason": "bad filter"}
+        status = SnapshotStatus.from_dict(data)
+        assert status.error == "bad filter"
+
+    def test_no_recognized_reason_leaves_error_none_but_keeps_raw(self):
+        data = {"status": "failed", "id": "s3", "weird_key": "boom"}
+        status = SnapshotStatus.from_dict(data)
+        assert status.error is None
+        assert status.raw == data  # raw is the fallback the download() message uses
+
+
+class TestDownloadFailureMessage:
+    async def test_failed_snapshot_surfaces_reason_and_id(self):
+        ds = _dataset()
+        ds.get_status = AsyncMock(
+            return_value=SnapshotStatus.from_dict(
+                {"status": "failed", "snapshot_id": "s1", "message": "quota exceeded"}
+            )
+        )
+        with pytest.raises(DatasetError) as excinfo:
+            await ds.download("s1")
+        msg = str(excinfo.value)
+        assert "quota exceeded" in msg
+        assert "s1" in msg
+        assert "None" not in msg  # the original bug must not reappear
+
+    async def test_failed_snapshot_without_reason_falls_back_to_raw(self):
+        ds = _dataset()
+        raw = {"status": "failed", "snapshot_id": "s9", "weird_key": "boom"}
+        ds.get_status = AsyncMock(return_value=SnapshotStatus.from_dict(raw))
+        with pytest.raises(DatasetError) as excinfo:
+            await ds.download("s9")
+        msg = str(excinfo.value)
+        assert "s9" in msg
+        assert "boom" in msg  # raw response surfaced instead of None
+        assert "Snapshot failed: None" not in msg
+
+    async def test_timeout_message_includes_id_and_status(self):
+        ds = _dataset()
+        ds.get_status = AsyncMock(
+            return_value=SnapshotStatus.from_dict({"status": "building", "snapshot_id": "s5"})
+        )
+        # timeout=-1 makes the timeout branch fire on the first poll (no sleep, no network).
+        with pytest.raises(TimeoutError) as excinfo:
+            await ds.download("s5", timeout=-1)
+        msg = str(excinfo.value)
+        assert "s5" in msg
+        assert "building" in msg

--- a/tests/unit/test_sync_client_coverage.py
+++ b/tests/unit/test_sync_client_coverage.py
@@ -1,0 +1,208 @@
+"""
+Tests for the sync-client parity coverage (Steps 1-5 of the plan).
+
+Two kinds of tests:
+  1. Drift-proof parity — derive the async surface (ScrapeService / SearchService
+     properties) and assert SyncBrightDataClient exposes every one, plus datasets.
+     Adding an async scraper without a sync wrapper will fail these automatically.
+  2. Functional — the new sync wrapper classes correctly delegate to their async
+     object on the persistent loop (tested in isolation with an AsyncMock async
+     object + a real loop, so no network and no full-client __enter__ needed).
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from brightdata import SyncBrightDataClient
+from brightdata.models import ScrapeResult
+from brightdata.discover.models import DiscoverSnapshot
+from brightdata.scrapers.service import ScrapeService
+from brightdata.serp.service import SearchService
+from brightdata.sync_client import (
+    SyncDatasetsClient,
+    SyncDataset,
+    SyncRedditScraper,
+    SyncTikTokScraper,
+    SyncYouTubeScraper,
+    SyncPerplexityScraper,
+    SyncDigiKeyScraper,
+    SyncTikTokSearchScraper,
+    SyncYouTubeSearchScraper,
+    SyncInstagramSearchScraper,
+)
+
+
+@pytest.fixture
+def loop():
+    lp = asyncio.new_event_loop()
+    yield lp
+    lp.close()
+
+
+def _client():
+    # Constructed, not entered: enough for structural/parity checks (no loop/network).
+    return SyncBrightDataClient(token="x" * 12)
+
+
+# ---------------------------------------------------------------------------
+# Drift-proof parity (structural; no loop needed)
+# ---------------------------------------------------------------------------
+
+
+class TestParity:
+    def test_datasets_property_exists(self):
+        """The 1.md bug: SyncBrightDataClient must expose `datasets`."""
+        c = _client()
+        assert hasattr(c, "datasets")
+        # dynamic dataset access resolves to a SyncDataset with the full method set
+        imdb = c.datasets.imdb_movies
+        for m in ("download", "get_status", "sample", "get_metadata"):
+            assert hasattr(imdb, m)
+
+    def test_scrape_surface_matches_async(self):
+        async_scrapers = [n for n, v in vars(ScrapeService).items() if isinstance(v, property)]
+        c = _client()
+        missing = [n for n in async_scrapers if not hasattr(c.scrape, n)]
+        assert not missing, f"sync scrape missing async scrapers: {missing}"
+
+    def test_search_surface_matches_async(self):
+        async_search = [n for n, v in vars(SearchService).items() if isinstance(v, property)]
+        c = _client()
+        missing = [n for n in async_search if not hasattr(c.search, n)]
+        assert not missing, f"sync search missing async verticals: {missing}"
+
+    def test_instagram_search_partials(self):
+        c = _client()
+        for m in ("posts", "reels", "profiles", "reels_all"):
+            assert hasattr(c.search.instagram, m)
+
+    def test_pinterest_trigger_poll(self):
+        c = _client()
+        for m in (
+            "posts_trigger",
+            "posts_status",
+            "posts_fetch",
+            "profiles_trigger",
+            "profiles_status",
+            "profiles_fetch",
+        ):
+            assert hasattr(c.scrape.pinterest, m)
+
+
+# ---------------------------------------------------------------------------
+# Functional: the new wrappers delegate to async on the loop (isolated)
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetsWrapper:
+    def test_dataset_call_returns_snapshot_id(self, loop):
+        async_ds = AsyncMock(return_value="snap_123")  # calling it -> snapshot_id
+        async_ds.download = AsyncMock(return_value=[{"r": 1}])
+        sd = SyncDataset(async_ds, loop)
+        sid = sd(filter={"name": "year", "operator": "=", "value": 2024}, records_limit=10)
+        assert sid == "snap_123"
+        assert sd.download(sid) == [{"r": 1}]
+
+    def test_datasets_client_getattr(self, loop):
+        async_datasets = MagicMock()
+        async_datasets.imdb_movies = AsyncMock(return_value="snap_1")
+        async_datasets.imdb_movies.download = AsyncMock(return_value=[{"x": 1}])
+        sdc = SyncDatasetsClient(async_datasets, loop)
+        assert sdc.imdb_movies(filter={}, records_limit=5) == "snap_1"
+        assert sdc.imdb_movies.download("snap_1") == [{"x": 1}]
+
+    def test_datasets_client_private_attr_guarded(self, loop):
+        sdc = SyncDatasetsClient(MagicMock(), loop)
+        with pytest.raises(AttributeError):
+            _ = sdc._not_a_dataset
+
+
+class TestScraperWrappers:
+    def test_reddit_posts_delegates(self, loop):
+        api = MagicMock()
+        api.posts = AsyncMock(return_value=ScrapeResult(success=True, data=[{"p": 1}]))
+        s = SyncRedditScraper(api, loop)
+        res = s.posts("https://reddit.com/r/python/...")
+        assert res.success and res.data == [{"p": 1}]
+        api.posts.assert_awaited_once()
+
+    def test_tiktok_trigger_status_fetch(self, loop):
+        api = MagicMock()
+        api.posts_trigger = AsyncMock(return_value="JOB")  # whatever async returns (job/snapshot)
+        api.posts_status = AsyncMock(return_value="ready")
+        api.posts_fetch = AsyncMock(return_value=[{"v": 1}])
+        s = SyncTikTokScraper(api, loop)
+        assert s.posts_trigger("u") == "JOB"
+        assert s.posts_status("sid") == "ready"
+        assert s.posts_fetch("sid") == [{"v": 1}]
+
+    def test_perplexity_and_digikey_resolve(self, loop):
+        api = MagicMock()
+        api.search = AsyncMock(return_value="ok")
+        assert SyncPerplexityScraper(api, loop).search("q") == "ok"
+        api2 = MagicMock()
+        api2.discover_by_category = AsyncMock(return_value="cat")
+        assert SyncDigiKeyScraper(api2, loop).discover_by_category("u") == "cat"
+
+    def test_youtube_videos_delegates(self, loop):
+        api = MagicMock()
+        api.videos = AsyncMock(return_value=ScrapeResult(success=True, data=[{"y": 1}]))
+        assert SyncYouTubeScraper(api, loop).videos("u").data == [{"y": 1}]
+
+
+class TestSearchWrappers:
+    def test_youtube_search_delegates(self, loop):
+        api = MagicMock()
+        api.videos_by_keyword = AsyncMock(return_value="SR")
+        assert SyncYouTubeSearchScraper(api, loop).videos_by_keyword("python") == "SR"
+
+    def test_tiktok_search_delegates(self, loop):
+        api = MagicMock()
+        api.posts_by_keyword = AsyncMock(return_value="SR")
+        assert SyncTikTokSearchScraper(api, loop).posts_by_keyword("#x") == "SR"
+
+    def test_instagram_search_new_methods(self, loop):
+        api = MagicMock()
+        api.profiles = AsyncMock(return_value="P")
+        api.reels_all = AsyncMock(return_value="R")
+        s = SyncInstagramSearchScraper(api, loop)
+        assert s.profiles("u") == "P"
+        assert s.reels_all("u") == "R"
+
+
+class TestDiscoverSyncPath:
+    """Discover's sync manual path — the one subsystem that had none before."""
+
+    def _client(self, loop):
+        c = SyncBrightDataClient(token="x" * 12)
+        c._loop = loop  # inject the loop; do NOT enter the context (no network)
+        return c
+
+    def test_discover_trigger_returns_colorless_snapshot(self, loop):
+        c = self._client(loop)
+        fake_job = MagicMock(task_id="t1", query="q", intent="i")
+        c._async_client.discover_trigger = AsyncMock(return_value=fake_job)
+        snap = c.discover_trigger("q", intent="i")
+        assert isinstance(snap, DiscoverSnapshot)
+        assert (snap.task_id, snap.query, snap.intent) == ("t1", "q", "i")
+        # colorless: no I/O methods on the handle
+        assert not hasattr(snap, "fetch")
+
+    def test_discover_status_wait_fetch_by_task_id(self, loop):
+        c = self._client(loop)
+        svc = MagicMock()
+        svc.status = AsyncMock(return_value="done")
+        svc.wait = AsyncMock(return_value="done")
+        svc.fetch = AsyncMock(return_value=[{"r": 1}])
+        c._async_client._discover_service = svc
+        assert c.discover_status("t1") == "done"
+        assert c.discover_wait("t1") == "done"
+        assert c.discover_fetch("t1") == [{"r": 1}]
+
+    def test_discover_service_is_ensured_when_missing(self, loop):
+        c = self._client(loop)
+        c._async_client._discover_service = None  # not yet created
+        svc = c._discover_service()
+        assert svc is not None and c._async_client._discover_service is svc


### PR DESCRIPTION
## Summary
  - Two changes + version bump **2.3.2 → 2.4.0**.

  - `SyncBrightDataClient` now mirrors the async surface: adds `datasets`, the TikTok/YouTube/Reddit/Perplexity/DigiKey scrapers,
  TikTok/YouTube search verticals, Pinterest trigger/status/fetch, and two Instagram-search methods (`profiles`, `reels_all`).
  - `BaseWebScraper` + `DiscoverService` gain id-driven `status`/`wait`/`fetch`/`to_result` — a triggered job is drivable without
  async-only job methods (colorless pattern, like the crawler); existing job methods unchanged.
  - **Contract note:** sync `discover_trigger()` now returns a colorless `DiscoverSnapshot` (drive via
  `discover_status`/`discover_fetch(task_id)`) instead of the async-only `DiscoverJob`, which couldn't be used from sync.

  ## Tests
  - Full unit suite green locally (248 passed); new tests cover the colorless verbs, sync parity, and the dataset error path.
