### PR TITLE
v2.4.1: X (Twitter) scraper + limit_per_input

### DIFF
--- a/notebooks/04_web_unlocker.ipynb
+++ b/notebooks/04_web_unlocker.ipynb
@@ -39,7 +39,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "API Token: 859a9772-4...4362\n",
+      "API Token: 02f48d4c-2...9a61\n",
       "Setup complete!\n"
      ]
     }
@@ -74,7 +74,7 @@
      "output_type": "stream",
      "text": [
       "Client initialized\n",
-      "SDK version: 2.3.0\n",
+      "SDK version: 2.3.2\n",
       "Default Web Unlocker zone: sdk_unlocker\n"
      ]
     }
@@ -117,12 +117,11 @@
       "Status: ready\n",
       "Method: web_unlocker\n",
       "\n",
-      "HTML length: 529 characters\n",
+      "HTML length: 559 characters\n",
       "\n",
       "First 500 characters:\n",
       "--------------------------------------------------\n",
-      "<!doctype html>\n",
-      "<html lang=\"en\"><head><title>Example Domain</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.org/domains/example\">Learn more\n",
+      "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><link rel=\"icon\" href=\"data:,\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href=\"https://iana.o\n",
       "--------------------------------------------------\n"
      ]
     }
@@ -176,15 +175,15 @@
       "\n",
       "Country: US\n",
       "  Success: True\n",
-      "  HTML length: 529 chars\n",
+      "  HTML length: 559 chars\n",
       "\n",
       "Country: GB\n",
       "  Success: True\n",
-      "  HTML length: 529 chars\n",
+      "  HTML length: 559 chars\n",
       "\n",
       "Country: DE\n",
       "  Success: True\n",
-      "  HTML length: 529 chars\n",
+      "  HTML length: 559 chars\n",
       "\n"
      ]
     }

--- a/notebooks/05_scraper_studio.ipynb
+++ b/notebooks/05_scraper_studio.ipynb
@@ -38,7 +38,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "API Token: 859a9772-4...4362\n",
+      "API Token: 02f48d4c-2...9a61\n",
       "Setup complete!\n"
      ]
     }
@@ -108,7 +108,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Job triggered: d2t1773025017352rhfek0rl202o\n"
+      "Job triggered: d2t1781612965274r71l9v16j93\n"
      ]
     }
    ],
@@ -132,19 +132,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Got 1 record(s)\n",
-      "  title: GOLDEN GATE\n",
-      "  price: {'value': 6600000, 'currency': 'TRY', 'symbol': '₺'}\n",
-      "  property_size: 100\n",
-      "  room_count: 3\n",
-      "  building_age: 6-10 arası\n"
+      "Not ready yet: Data not ready for response_id=d2t1781612965274r71l9v16j93\n",
+      "Re-run this cell in a few seconds.\n"
      ]
     }
    ],

--- a/notebooks/web_scrapers/x.ipynb
+++ b/notebooks/web_scrapers/x.ipynb
@@ -1,0 +1,527 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-0",
+   "metadata": {},
+   "source": [
+    "# X (Twitter) Scraper\n",
+    "\n",
+    "Test all X scraper endpoints (`client.scrape.x`):\n",
+    "- **Posts — collect by URL**\n",
+    "- **Posts — discover by profile URL** (optional date range)\n",
+    "- **Posts — discover by profiles array** (many profiles in one request)\n",
+    "- **Profiles — collect by URL** (cap posts via `max_number_of_posts`)\n",
+    "- **Profiles — discover by user name**\n",
+    "\n",
+    "Two datasets back this scraper: posts (`gd_lwxkxvnf1cynvib9co`) and profiles (`gd_lwxmeb2u1cniijd7t4`).\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "x-cell-2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API Token: 02f48d4c-2...9a61\n",
+      "SDK Version: 2.3.2\n",
+      "SDK Location: /Users/ns/Desktop/projects/sdk-python/src/brightdata/__init__.py\n",
+      "Setup complete!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()\n",
+    "\n",
+    "API_TOKEN = os.getenv(\"BRIGHTDATA_API_TOKEN\")\n",
+    "if not API_TOKEN:\n",
+    "    raise ValueError(\"Set BRIGHTDATA_API_TOKEN in .env file\")\n",
+    "\n",
+    "print(f\"API Token: {API_TOKEN[:10]}...{API_TOKEN[-4:]}\")\n",
+    "\n",
+    "# Check SDK version and location\n",
+    "import brightdata\n",
+    "print(f\"SDK Version: {brightdata.__version__}\")\n",
+    "print(f\"SDK Location: {brightdata.__file__}\")\n",
+    "print(\"Setup complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-3",
+   "metadata": {},
+   "source": [
+    "## Initialize Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "x-cell-4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Client initialized\n"
+     ]
+    }
+   ],
+   "source": [
+    "from brightdata import BrightDataClient\n",
+    "\n",
+    "client = BrightDataClient(token=API_TOKEN)\n",
+    "\n",
+    "print(\"Client initialized\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-5",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 1: Posts — Collect by URL (single)\n",
+    "\n",
+    "Scrape a single X post by its status URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "x-cell-6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scraping post: https://x.com/FabrizioRomano/status/1683559267524136962\n",
+      "\n",
+      "Success: True\n",
+      "Status: ready\n",
+      "\n",
+      "=== Post Data (33 fields) ===\n",
+      "  id: 1683559267524136962\n",
+      "  user_posted: FabrizioRomano\n",
+      "  name: Fabrizio Romano\n",
+      "  description: Here we go? 😵‍💫🏀🇸🇦\n",
+      "  date_posted: 2023-07-24T19:26:23.000Z\n",
+      "  photos: None\n",
+      "  url: https://x.com/FabrizioRomano/status/1683559267524136962\n",
+      "  quoted_post: {'photos': None, 'videos': None}\n",
+      "  tagged_users: None\n",
+      "  replies: 2569\n",
+      "  reposts: 13133\n",
+      "  likes: 244053\n",
+      "  views: 19868955\n",
+      "  external_url: None\n",
+      "  hashtags: None\n",
+      "  followers: 27933860\n",
+      "  biography: Here we go! © fabrizio.romano93@gmail.com 📩\n",
+      "  posts_count: 71978\n",
+      "  profile_image_link: https://pbs.twimg.com/profile_images/1741753635158024192/j0m8Ucvv_normal.jpg\n",
+      "  following: 2668\n",
+      "  is_verified: True\n",
+      "  quotes: 606\n",
+      "  bookmarks: 675\n",
+      "  parent_post_details: {'post_id': '1683559267524136962', 'profile_id': '330262748', 'profile_name': 'F...\n",
+      "  external_image_urls: None\n",
+      "  videos: None\n",
+      "  external_video_urls: None\n",
+      "  verification_type: blue\n",
+      "  user_id: 330262748\n",
+      "  context_added: None\n",
+      "  is_repost: False\n",
+      "  timestamp: 2026-06-19T09:50:50.838Z\n",
+      "  input: {'url': 'https://x.com/FabrizioRomano/status/1683559267524136962'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "POST_URL = \"https://x.com/FabrizioRomano/status/1683559267524136962\"\n",
+    "\n",
+    "print(f\"Scraping post: {POST_URL}\\n\")\n",
+    "\n",
+    "async with client:\n",
+    "    result = await client.scrape.x.posts(url=POST_URL)\n",
+    "\n",
+    "print(f\"Success: {result.success}\")\n",
+    "print(f\"Status: {result.status}\")\n",
+    "\n",
+    "if result.success and result.data:\n",
+    "    data = result.data\n",
+    "    print(f\"\\n=== Post Data ({len(data)} fields) ===\")\n",
+    "    for key, value in data.items():\n",
+    "        val_str = str(value)[:80] + \"...\" if len(str(value)) > 80 else str(value)\n",
+    "        print(f\"  {key}: {val_str}\")\n",
+    "else:\n",
+    "    print(f\"\\nError: {result.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-7",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 2: Posts — Collect by URL (batch)\n",
+    "\n",
+    "Scrape several posts at once by passing a list of URLs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "x-cell-8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Batch scraping 2 posts...\n",
+      "Success: True | Status: ready\n",
+      "Got 2 post(s):\n",
+      "\n",
+      "=== Post 1 ===\n",
+      "  User: CNN\n",
+      "  Text: Marian Robinson, the mother of former first lady Michelle Obama, has died, accor\n",
+      "  URL:  https://x.com/CNN/status/1796673270344810776\n",
+      "\n",
+      "=== Post 2 ===\n",
+      "  User: FabrizioRomano\n",
+      "  Text: …and this is how AS Roma unveiled Paulo Dybala as new signing tonight, in front \n",
+      "  URL:  https://x.com/FabrizioRomano/status/1552015619251634176\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "POST_URLS = [\n",
+    "    \"https://x.com/FabrizioRomano/status/1552015619251634176\",\n",
+    "    \"https://x.com/CNN/status/1796673270344810776\",\n",
+    "]\n",
+    "\n",
+    "print(f\"Batch scraping {len(POST_URLS)} posts...\")\n",
+    "\n",
+    "async with client:\n",
+    "    result = await client.scrape.x.posts(url=POST_URLS)\n",
+    "\n",
+    "# A batch call returns a single ScrapeResult whose .data holds all the posts\n",
+    "# (one record per input URL), not a list of ScrapeResult objects.\n",
+    "print(f\"Success: {result.success} | Status: {result.status}\")\n",
+    "\n",
+    "if result.success and result.data:\n",
+    "    posts = result.data if isinstance(result.data, list) else [result.data]\n",
+    "    print(f\"Got {len(posts)} post(s):\")\n",
+    "    print()\n",
+    "    for i, post in enumerate(posts):\n",
+    "        print(f\"=== Post {i+1} ===\")\n",
+    "        print(f\"  User: {post.get('user_posted', 'N/A')}\")\n",
+    "        print(f\"  Text: {str(post.get('description', post.get('text', 'N/A')))[:80]}\")\n",
+    "        print(f\"  URL:  {post.get('url', 'N/A')}\")\n",
+    "        print()\n",
+    "else:\n",
+    "    print(f\"Error: {result.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-9",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 3: Posts — Discover by Profile URL\n",
+    "\n",
+    "Discover posts from a profile, optionally within a date range. The same range\n",
+    "applies to all URLs. Leave the dates out to discover without a window."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "x-cell-10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROFILE_URL = \"https://x.com/elonmusk\"\n",
+    "\n",
+    "print(f\"Discovering posts from: {PROFILE_URL}\")\n",
+    "\n",
+    "async with client:\n",
+    "    result = await client.scrape.x.posts_by_profile(\n",
+    "        url=PROFILE_URL,\n",
+    "        start_date=\"2024-01-01\",\n",
+    "        end_date=\"2024-03-15\",\n",
+    "        limit_per_input=2,  # cap posts per profile (small/fast while testing)\n",
+    "    )\n",
+    "\n",
+    "print(f\"Success: {result.success} | Status: {result.status}\")\n",
+    "\n",
+    "if result.success and result.data:\n",
+    "    posts = result.data if isinstance(result.data, list) else [result.data]\n",
+    "    print(f\"Discovered {len(posts)} post(s).\")\n",
+    "    print()\n",
+    "    for i, p in enumerate(posts):\n",
+    "        # Many posts have no caption (media-only / reposts) -> description is None.\n",
+    "        text = p.get(\"description\") or \"(no caption - media/repost)\"\n",
+    "        has_media = bool(p.get(\"photos\") or p.get(\"videos\"))\n",
+    "        print(f\"=== Post {i+1} ===\")\n",
+    "        print(f\"  Date:  {p.get('date_posted', 'N/A')}\")\n",
+    "        print(f\"  Text:  {str(text)[:80]}\")\n",
+    "        print(f\"  Likes: {p.get('likes', 'N/A')} | Reposts: {p.get('reposts', 'N/A')}\")\n",
+    "        print(f\"  Media: {'yes' if has_media else 'no'}\")\n",
+    "        print(f\"  URL:   {p.get('url', 'N/A')}\")\n",
+    "        print()\n",
+    "\n",
+    "    # Full field dump of the first record, to see everything the API returns\n",
+    "    print(\"=== First record - all fields ===\")\n",
+    "    for k, v in posts[0].items():\n",
+    "        vs = str(v)[:80] + \"...\" if len(str(v)) > 80 else str(v)\n",
+    "        print(f\"  {k}: {vs}\")\n",
+    "else:\n",
+    "    print(f\"Error: {result.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-11",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 4: Posts — Discover by Profiles Array\n",
+    "\n",
+    "Discover posts from several profiles in a single request (one input row carrying\n",
+    "the whole array of profile URLs)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "x-cell-12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success: True | Status: ready\n",
+      "Discovered 1 post(s) across 2 profiles\n",
+      "\n",
+      "  1. @N/A: (no caption - media/repost)\n"
+     ]
+    }
+   ],
+   "source": [
+    "PROFILE_URLS = [\n",
+    "    \"https://x.com/cnn\",\n",
+    "    \"https://x.com/BSCNews\",\n",
+    "\n",
+    "]\n",
+    "\n",
+    "# Cap each profile to a few posts so the job stays small and fast while testing.\n",
+    "async with client:\n",
+    "    result = await client.scrape.x.posts_by_profiles_array(\n",
+    "        urls=PROFILE_URLS, limit_per_input=2, timeout=1000\n",
+    "    )\n",
+    "\n",
+    "print(f\"Success: {result.success} | Status: {result.status}\")\n",
+    "\n",
+    "if result.success and result.data:\n",
+    "    posts = result.data if isinstance(result.data, list) else [result.data]\n",
+    "    print(f\"Discovered {len(posts)} post(s) across {len(PROFILE_URLS)} profiles\")\n",
+    "    print()\n",
+    "    for i, p in enumerate(posts[:10]):\n",
+    "        text = p.get(\"description\") or \"(no caption - media/repost)\"\n",
+    "        print(f\"  {i+1}. @{p.get('user_posted', 'N/A')}: {str(text)[:70]}\")\n",
+    "else:\n",
+    "    print(f\"Error: {result.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-13",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 5: Profiles — Collect by URL\n",
+    "\n",
+    "Collect a profile by its URL. `max_number_of_posts` caps how many posts to pull."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "x-cell-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROFILE_URL = \"https://x.com/elonmusk\"\n",
+    "\n",
+    "async with client:\n",
+    "    result = await client.scrape.x.profiles(url=PROFILE_URL, max_number_of_posts=20)\n",
+    "\n",
+    "print(f\"Success: {result.success} | Status: {result.status}\")\n",
+    "\n",
+    "if result.success and result.data:\n",
+    "    data = result.data\n",
+    "    print(f\"\\n=== Profile Data ({len(data)} fields) ===\")\n",
+    "    for key, value in data.items():\n",
+    "        val_str = str(value)[:80] + \"...\" if len(str(value)) > 80 else str(value)\n",
+    "        print(f\"  {key}: {val_str}\")\n",
+    "else:\n",
+    "    print(f\"Error: {result.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-15",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 6: Profiles — Discover by User Name\n",
+    "\n",
+    "Discover a profile by handle (no URL needed) — pass one handle or a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "x-cell-16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "USER_NAMES = [\"elonmusk\", \"BillGates\"]\n",
+    "\n",
+    "async with client:\n",
+    "    result = await client.scrape.x.profiles_by_username(user_name=USER_NAMES)\n",
+    "\n",
+    "print(f\"Success: {result.success} | Status: {result.status}\")\n",
+    "\n",
+    "if result.success and result.data:\n",
+    "    profiles = result.data if isinstance(result.data, list) else [result.data]\n",
+    "    print(f\"\\nDiscovered {len(profiles)} profile(s):\")\n",
+    "    for pr in profiles:\n",
+    "        print(f\"  - {pr.get('name', 'N/A')} (@{pr.get('id', pr.get('user_name', 'N/A'))})\")\n",
+    "else:\n",
+    "    print(f\"Error: {result.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-17",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Test 7: Manual Job Control (Trigger / Status / Fetch)\n",
+    "\n",
+    "For long-running operations, control the workflow manually. Every verb has a\n",
+    "matching `*_trigger` / `*_status` / `*_fetch` (here shown for posts)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "x-cell-18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "\n",
+    "POST_URL = \"https://x.com/CNN/status/1796673270344810776\"\n",
+    "\n",
+    "print(f\"Manual workflow for: {POST_URL}\\n\")\n",
+    "\n",
+    "async with client:\n",
+    "    # Step 1: trigger\n",
+    "    print(\"Step 1: Triggering scrape...\")\n",
+    "    job = await client.scrape.x.posts_trigger(url=POST_URL)\n",
+    "    print(f\"  Job ID: {job.snapshot_id}\")\n",
+    "\n",
+    "    # Step 2: poll\n",
+    "    print(\"\\nStep 2: Polling for status...\")\n",
+    "    while True:\n",
+    "        status = await job.status()\n",
+    "        print(f\"  Status: {status}\")\n",
+    "        if status == \"ready\":\n",
+    "            break\n",
+    "        elif status in (\"error\", \"failed\"):\n",
+    "            print(\"  Job failed!\")\n",
+    "            break\n",
+    "        await asyncio.sleep(5)\n",
+    "\n",
+    "    # Step 3: fetch\n",
+    "    if status == \"ready\":\n",
+    "        print(\"\\nStep 3: Fetching results...\")\n",
+    "        data = await job.fetch()\n",
+    "        item = data[0] if isinstance(data, list) else data\n",
+    "        print(f\"  Got: {str(item)[:120]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x-cell-19",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Sync usage\n",
+    "\n",
+    "Every method is also available synchronously via `SyncBrightDataClient`\n",
+    "(`client.scrape.x.<method>(...)` with no `await`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "x-cell-20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from brightdata import SyncBrightDataClient\n",
+    "\n",
+    "with SyncBrightDataClient(token=API_TOKEN) as sync_client:\n",
+    "    result = sync_client.scrape.x.posts(url=\"https://x.com/CNN/status/1796673270344810776\")\n",
+    "    print(f\"Success: {result.success} | Status: {result.status}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.11.10)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ where = ["src"]
 
 [project]
 name = "brightdata-sdk"
-version = "2.4.0"
+version = "2.4.1"
 description = "Modern async-first Python SDK for Bright Data APIs"
 authors = [{name = "Bright Data", email = "support@brightdata.com"}]
 license = {text = "MIT"}

--- a/src/brightdata/scrapers/__init__.py
+++ b/src/brightdata/scrapers/__init__.py
@@ -70,6 +70,11 @@ try:
 except ImportError:
     RedditScraper = None
 
+try:
+    from .x.scraper import XScraper
+except ImportError:
+    XScraper = None
+
 
 __all__ = [
     "BaseWebScraper",
@@ -91,4 +96,5 @@ __all__ = [
     "YouTubeSearchScraper",
     "DigiKeyScraper",
     "RedditScraper",
+    "XScraper",
 ]

--- a/src/brightdata/scrapers/api_client.py
+++ b/src/brightdata/scrapers/api_client.py
@@ -46,6 +46,7 @@ class DatasetAPIClient:
         include_errors: bool = True,
         sdk_function: Optional[str] = None,
         extra_params: Optional[Dict[str, str]] = None,
+        limit_per_input: Optional[int] = None,
     ) -> Optional[str]:
         """
         Trigger dataset collection and get snapshot_id.
@@ -75,8 +76,15 @@ class DatasetAPIClient:
         if extra_params:
             params.update(extra_params)
 
+        # Most datasets accept the bare input array as the body. When a
+        # limit_per_input cap is requested, send the wrapped body shape the
+        # Datasets v3 API documents: {"input": [...], "limit_per_input": N}.
+        body: Any = payload
+        if limit_per_input is not None:
+            body = {"input": payload, "limit_per_input": limit_per_input}
+
         async with self.engine.post_to_url(
-            self.TRIGGER_URL, json_data=payload, params=params
+            self.TRIGGER_URL, json_data=body, params=params
         ) as response:
             if response.status == HTTPStatus.OK:
                 data = await response.json()

--- a/src/brightdata/scrapers/service.py
+++ b/src/brightdata/scrapers/service.py
@@ -32,6 +32,7 @@ class ScrapeService:
         self._digikey = None
         self._reddit = None
         self._pinterest = None
+        self._x = None
 
     @property
     def amazon(self):
@@ -378,3 +379,31 @@ class ScrapeService:
                 bearer_token=self._client.token, engine=self._client.engine
             )
         return self._pinterest
+
+    @property
+    def x(self):
+        """
+        Access X (Twitter) scraper.
+
+        Returns:
+            XScraper instance for X posts and profiles (collect + discover)
+
+        Example:
+            >>> # Posts by URL
+            >>> result = await client.scrape.x.posts(
+            ...     url="https://x.com/FabrizioRomano/status/1683559267524136962"
+            ... )
+            >>>
+            >>> # Discover posts from a profile (optional date range)
+            >>> result = await client.scrape.x.posts_by_profile(
+            ...     url="https://x.com/elonmusk", start_date="2023-01-15"
+            ... )
+            >>>
+            >>> # Discover a profile by handle
+            >>> result = await client.scrape.x.profiles_by_username(user_name="elonmusk")
+        """
+        if self._x is None:
+            from .x import XScraper
+
+            self._x = XScraper(bearer_token=self._client.token, engine=self._client.engine)
+        return self._x

--- a/src/brightdata/scrapers/workflow.py
+++ b/src/brightdata/scrapers/workflow.py
@@ -53,6 +53,7 @@ class WorkflowExecutor:
         normalize_func: Optional[Callable[[Any], Any]] = None,
         sdk_function: Optional[str] = None,
         extra_params: Optional[Dict[str, str]] = None,
+        limit_per_input: Optional[int] = None,
     ) -> ScrapeResult:
         """
         Execute complete trigger/poll/fetch workflow.
@@ -80,6 +81,7 @@ class WorkflowExecutor:
                 include_errors=include_errors,
                 sdk_function=sdk_function,
                 extra_params=extra_params,
+                limit_per_input=limit_per_input,
             )
         except APIError as e:
             return ScrapeResult(

--- a/src/brightdata/scrapers/x/__init__.py
+++ b/src/brightdata/scrapers/x/__init__.py
@@ -1,0 +1,3 @@
+from .scraper import XScraper
+
+__all__ = ["XScraper"]

--- a/src/brightdata/scrapers/x/scraper.py
+++ b/src/brightdata/scrapers/x/scraper.py
@@ -1,0 +1,673 @@
+"""
+X (formerly Twitter) scraper - posts and profiles, collect-by-URL and discovery.
+
+Two datasets back this scraper:
+- Posts    (gd_lwxkxvnf1cynvib9co): collect by URL, discover by profile url,
+           discover by profiles array.
+- Profiles (gd_lwxmeb2u1cniijd7t4): collect by URL, discover by user name.
+
+Every method takes an optional ``limit_per_input`` to cap how many records are
+collected per input (smaller = faster jobs); leaving it None means no cap.
+
+API surface (mirrors the other scrapers - each verb has async + _sync +
+_trigger/_status/_fetch):
+- client.scrape.x.posts(url, ...)                                  # posts by URL
+- client.scrape.x.posts_by_profile(url, start_date, end_date)      # discover_by=profile_url
+- client.scrape.x.posts_by_profiles_array(urls, start_date, end_date)  # discover_by=profiles_array
+- client.scrape.x.profiles(url, max_number_of_posts)               # profiles by URL
+- client.scrape.x.profiles_by_username(user_name)                  # discover_by=user_name
+"""
+
+import asyncio
+from typing import List, Any, Union, Optional
+
+from ..base import BaseWebScraper
+from ..registry import register
+from ..job import ScrapeJob
+from ...models import ScrapeResult
+from ...utils.validation import validate_url, validate_url_list
+from ...utils.function_detection import get_caller_function_name
+from ...constants import DEFAULT_POLL_INTERVAL, DEFAULT_TIMEOUT_MEDIUM, DEFAULT_COST_PER_RECORD
+
+
+@register("x")
+class XScraper(BaseWebScraper):
+    """
+    X (Twitter) scraper for posts and profiles.
+
+    Example:
+        >>> scraper = XScraper(bearer_token="token")
+        >>>
+        >>> # Posts by URL
+        >>> result = await scraper.posts(
+        ...     url="https://x.com/FabrizioRomano/status/1683559267524136962"
+        ... )
+        >>>
+        >>> # Discover posts from a profile, capped + within a date range
+        >>> result = await scraper.posts_by_profile(
+        ...     url="https://x.com/elonmusk",
+        ...     start_date="2023-01-15",
+        ...     end_date="2024-03-15",
+        ...     limit_per_input=50,
+        ... )
+        >>>
+        >>> # Discover posts from several profiles in one request
+        >>> result = await scraper.posts_by_profiles_array(
+        ...     urls=["https://x.com/cnn", "https://x.com/BSCNews"],
+        ...     limit_per_input=50,
+        ... )
+        >>>
+        >>> # Profile by URL (cap how many posts to pull)
+        >>> result = await scraper.profiles(url="https://x.com/elonmusk", max_number_of_posts=100)
+        >>>
+        >>> # Discover a profile by handle
+        >>> result = await scraper.profiles_by_username(user_name="elonmusk")
+    """
+
+    # Posts is the default dataset (satisfies BaseWebScraper's DATASET_ID requirement)
+    DATASET_ID = "gd_lwxkxvnf1cynvib9co"  # Posts (default)
+    DATASET_ID_POSTS = "gd_lwxkxvnf1cynvib9co"
+    DATASET_ID_PROFILES = "gd_lwxmeb2u1cniijd7t4"
+
+    PLATFORM_NAME = "x"
+    MIN_POLL_TIMEOUT = DEFAULT_TIMEOUT_MEDIUM
+    COST_PER_RECORD = DEFAULT_COST_PER_RECORD
+
+    # ============================================================================
+    # POSTS - Collect by URL
+    # ============================================================================
+
+    async def posts(
+        self,
+        url: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> Union[ScrapeResult, List[ScrapeResult]]:
+        """
+        Collect X posts by post URL (async).
+
+        Args:
+            url: Post URL(s) like https://x.com/<user>/status/<id>
+            limit_per_input: Optional cap on records collected per input URL.
+            timeout: Maximum wait time in seconds (default: 240)
+
+        Returns:
+            ScrapeResult or List[ScrapeResult] with post data
+        """
+        if isinstance(url, str):
+            validate_url(url)
+        else:
+            validate_url_list(url)
+
+        is_single = isinstance(url, str)
+        url_list = [url] if is_single else url
+        payload = [{"url": u} for u in url_list]
+
+        sdk_function = get_caller_function_name()
+        result = await self.workflow_executor.execute(
+            payload=payload,
+            dataset_id=self.DATASET_ID_POSTS,
+            poll_interval=DEFAULT_POLL_INTERVAL,
+            poll_timeout=timeout,
+            include_errors=True,
+            sdk_function=sdk_function,
+            normalize_func=self.normalize_result,
+            limit_per_input=limit_per_input,
+        )
+
+        if is_single and isinstance(result.data, list) and len(result.data) == 1:
+            result.url = url
+            result.data = result.data[0]
+        return result
+
+    def posts_sync(
+        self,
+        url: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> Union[ScrapeResult, List[ScrapeResult]]:
+        """Collect X posts by post URL (sync)."""
+
+        async def _run():
+            async with self.engine:
+                return await self.posts(url, limit_per_input=limit_per_input, timeout=timeout)
+
+        return asyncio.run(_run())
+
+    # --- Posts Trigger/Status/Fetch ---
+
+    async def posts_trigger(
+        self,
+        url: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X posts collection by URL (manual control)."""
+        url_list = [url] if isinstance(url, str) else url
+        payload = [{"url": u} for u in url_list]
+
+        snapshot_id = await self.api_client.trigger(
+            payload=payload,
+            dataset_id=self.DATASET_ID_POSTS,
+            limit_per_input=limit_per_input,
+        )
+        return ScrapeJob(
+            snapshot_id=snapshot_id,
+            api_client=self.api_client,
+            platform_name=self.PLATFORM_NAME,
+            cost_per_record=self.COST_PER_RECORD,
+        )
+
+    def posts_trigger_sync(
+        self,
+        url: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X posts collection by URL (sync)."""
+        return asyncio.run(self.posts_trigger(url, limit_per_input=limit_per_input))
+
+    async def posts_status(self, snapshot_id: str) -> str:
+        """Check X posts collection status."""
+        return await self._check_status_async(snapshot_id)
+
+    def posts_status_sync(self, snapshot_id: str) -> str:
+        """Check X posts collection status (sync)."""
+        return asyncio.run(self.posts_status(snapshot_id))
+
+    async def posts_fetch(self, snapshot_id: str) -> Any:
+        """Fetch X posts results."""
+        return await self._fetch_results_async(snapshot_id)
+
+    def posts_fetch_sync(self, snapshot_id: str) -> Any:
+        """Fetch X posts results (sync)."""
+        return asyncio.run(self.posts_fetch(snapshot_id))
+
+    # ============================================================================
+    # POSTS - Discover by profile URL
+    # ============================================================================
+
+    async def posts_by_profile(
+        self,
+        url: Union[str, List[str]],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> ScrapeResult:
+        """
+        Discover X posts from a profile URL (async).
+
+        Args:
+            url: Profile URL(s) like https://x.com/<user>
+            start_date: Optional start of the date range (e.g. "2023-01-15" or ISO 8601).
+            end_date: Optional end of the date range. The same range applies to all URLs.
+            limit_per_input: Optional cap on posts discovered per profile (smaller = faster).
+            timeout: Maximum wait time in seconds (default: 240)
+
+        Returns:
+            ScrapeResult with the discovered posts
+        """
+        if isinstance(url, str):
+            validate_url(url)
+        else:
+            validate_url_list(url)
+
+        url_list = [url] if isinstance(url, str) else url
+        payload = [
+            {"url": u, "start_date": start_date or "", "end_date": end_date or ""} for u in url_list
+        ]
+
+        sdk_function = get_caller_function_name()
+        return await self.workflow_executor.execute(
+            payload=payload,
+            dataset_id=self.DATASET_ID_POSTS,
+            poll_interval=DEFAULT_POLL_INTERVAL,
+            poll_timeout=timeout,
+            include_errors=True,
+            sdk_function=sdk_function,
+            normalize_func=self.normalize_result,
+            extra_params={"type": "discover_new", "discover_by": "profile_url"},
+            limit_per_input=limit_per_input,
+        )
+
+    def posts_by_profile_sync(
+        self,
+        url: Union[str, List[str]],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> ScrapeResult:
+        """Discover X posts from a profile URL (sync)."""
+
+        async def _run():
+            async with self.engine:
+                return await self.posts_by_profile(
+                    url,
+                    start_date=start_date,
+                    end_date=end_date,
+                    limit_per_input=limit_per_input,
+                    timeout=timeout,
+                )
+
+        return asyncio.run(_run())
+
+    # --- Discover-by-profile Trigger/Status/Fetch ---
+
+    async def posts_by_profile_trigger(
+        self,
+        url: Union[str, List[str]],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X posts discovery by profile URL (manual control)."""
+        url_list = [url] if isinstance(url, str) else url
+        payload = [
+            {"url": u, "start_date": start_date or "", "end_date": end_date or ""} for u in url_list
+        ]
+
+        snapshot_id = await self.api_client.trigger(
+            payload=payload,
+            dataset_id=self.DATASET_ID_POSTS,
+            extra_params={"type": "discover_new", "discover_by": "profile_url"},
+            limit_per_input=limit_per_input,
+        )
+        return ScrapeJob(
+            snapshot_id=snapshot_id,
+            api_client=self.api_client,
+            platform_name=self.PLATFORM_NAME,
+            cost_per_record=self.COST_PER_RECORD,
+        )
+
+    def posts_by_profile_trigger_sync(
+        self,
+        url: Union[str, List[str]],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X posts discovery by profile URL (sync)."""
+        return asyncio.run(
+            self.posts_by_profile_trigger(
+                url, start_date=start_date, end_date=end_date, limit_per_input=limit_per_input
+            )
+        )
+
+    async def posts_by_profile_status(self, snapshot_id: str) -> str:
+        """Check X posts-by-profile discovery status."""
+        return await self._check_status_async(snapshot_id)
+
+    def posts_by_profile_status_sync(self, snapshot_id: str) -> str:
+        """Check X posts-by-profile discovery status (sync)."""
+        return asyncio.run(self.posts_by_profile_status(snapshot_id))
+
+    async def posts_by_profile_fetch(self, snapshot_id: str) -> Any:
+        """Fetch X posts-by-profile discovery results."""
+        return await self._fetch_results_async(snapshot_id)
+
+    def posts_by_profile_fetch_sync(self, snapshot_id: str) -> Any:
+        """Fetch X posts-by-profile discovery results (sync)."""
+        return asyncio.run(self.posts_by_profile_fetch(snapshot_id))
+
+    # ============================================================================
+    # POSTS - Discover by profiles array
+    # ============================================================================
+
+    async def posts_by_profiles_array(
+        self,
+        urls: List[str],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> ScrapeResult:
+        """
+        Discover X posts from several profile URLs in a single request (async).
+
+        Unlike posts_by_profile (one input row per URL), this sends one input row
+        containing the whole array of profile URLs.
+
+        Args:
+            urls: List of profile URLs like https://x.com/<user>
+            start_date: Optional start of the date range (applies to all URLs).
+            end_date: Optional end of the date range.
+            limit_per_input: Optional cap on posts discovered (smaller = faster).
+            timeout: Maximum wait time in seconds (default: 240)
+
+        Returns:
+            ScrapeResult with the discovered posts
+        """
+        validate_url_list(urls)
+
+        payload = [{"urls": list(urls), "start_date": start_date or "", "end_date": end_date or ""}]
+
+        sdk_function = get_caller_function_name()
+        return await self.workflow_executor.execute(
+            payload=payload,
+            dataset_id=self.DATASET_ID_POSTS,
+            poll_interval=DEFAULT_POLL_INTERVAL,
+            poll_timeout=timeout,
+            include_errors=True,
+            sdk_function=sdk_function,
+            normalize_func=self.normalize_result,
+            extra_params={"type": "discover_new", "discover_by": "profiles_array"},
+            limit_per_input=limit_per_input,
+        )
+
+    def posts_by_profiles_array_sync(
+        self,
+        urls: List[str],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> ScrapeResult:
+        """Discover X posts from several profile URLs in one request (sync)."""
+
+        async def _run():
+            async with self.engine:
+                return await self.posts_by_profiles_array(
+                    urls,
+                    start_date=start_date,
+                    end_date=end_date,
+                    limit_per_input=limit_per_input,
+                    timeout=timeout,
+                )
+
+        return asyncio.run(_run())
+
+    # --- Discover-by-profiles-array Trigger/Status/Fetch ---
+
+    async def posts_by_profiles_array_trigger(
+        self,
+        urls: List[str],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X posts discovery by profiles array (manual control)."""
+        validate_url_list(urls)
+        payload = [{"urls": list(urls), "start_date": start_date or "", "end_date": end_date or ""}]
+
+        snapshot_id = await self.api_client.trigger(
+            payload=payload,
+            dataset_id=self.DATASET_ID_POSTS,
+            extra_params={"type": "discover_new", "discover_by": "profiles_array"},
+            limit_per_input=limit_per_input,
+        )
+        return ScrapeJob(
+            snapshot_id=snapshot_id,
+            api_client=self.api_client,
+            platform_name=self.PLATFORM_NAME,
+            cost_per_record=self.COST_PER_RECORD,
+        )
+
+    def posts_by_profiles_array_trigger_sync(
+        self,
+        urls: List[str],
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X posts discovery by profiles array (sync)."""
+        return asyncio.run(
+            self.posts_by_profiles_array_trigger(
+                urls, start_date=start_date, end_date=end_date, limit_per_input=limit_per_input
+            )
+        )
+
+    async def posts_by_profiles_array_status(self, snapshot_id: str) -> str:
+        """Check X posts-by-profiles-array discovery status."""
+        return await self._check_status_async(snapshot_id)
+
+    def posts_by_profiles_array_status_sync(self, snapshot_id: str) -> str:
+        """Check X posts-by-profiles-array discovery status (sync)."""
+        return asyncio.run(self.posts_by_profiles_array_status(snapshot_id))
+
+    async def posts_by_profiles_array_fetch(self, snapshot_id: str) -> Any:
+        """Fetch X posts-by-profiles-array discovery results."""
+        return await self._fetch_results_async(snapshot_id)
+
+    def posts_by_profiles_array_fetch_sync(self, snapshot_id: str) -> Any:
+        """Fetch X posts-by-profiles-array discovery results (sync)."""
+        return asyncio.run(self.posts_by_profiles_array_fetch(snapshot_id))
+
+    # ============================================================================
+    # PROFILES - Collect by URL
+    # ============================================================================
+
+    async def profiles(
+        self,
+        url: Union[str, List[str]],
+        max_number_of_posts: Optional[int] = None,
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> Union[ScrapeResult, List[ScrapeResult]]:
+        """
+        Collect X profile data by profile URL (async).
+
+        Args:
+            url: Profile URL(s) like https://x.com/<user>
+            max_number_of_posts: Optional cap on how many posts to pull per profile.
+            limit_per_input: Optional cap on records collected per input.
+            timeout: Maximum wait time in seconds (default: 240)
+
+        Returns:
+            ScrapeResult or List[ScrapeResult] with profile data
+        """
+        if isinstance(url, str):
+            validate_url(url)
+        else:
+            validate_url_list(url)
+
+        is_single = isinstance(url, str)
+        url_list = [url] if is_single else url
+        payload = []
+        for u in url_list:
+            item: dict = {"url": u}
+            if max_number_of_posts is not None:
+                item["max_number_of_posts"] = max_number_of_posts
+            payload.append(item)
+
+        sdk_function = get_caller_function_name()
+        result = await self.workflow_executor.execute(
+            payload=payload,
+            dataset_id=self.DATASET_ID_PROFILES,
+            poll_interval=DEFAULT_POLL_INTERVAL,
+            poll_timeout=timeout,
+            include_errors=True,
+            sdk_function=sdk_function,
+            normalize_func=self.normalize_result,
+            limit_per_input=limit_per_input,
+        )
+
+        if is_single and isinstance(result.data, list) and len(result.data) == 1:
+            result.url = url
+            result.data = result.data[0]
+        return result
+
+    def profiles_sync(
+        self,
+        url: Union[str, List[str]],
+        max_number_of_posts: Optional[int] = None,
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> Union[ScrapeResult, List[ScrapeResult]]:
+        """Collect X profile data by profile URL (sync)."""
+
+        async def _run():
+            async with self.engine:
+                return await self.profiles(
+                    url,
+                    max_number_of_posts=max_number_of_posts,
+                    limit_per_input=limit_per_input,
+                    timeout=timeout,
+                )
+
+        return asyncio.run(_run())
+
+    # --- Profiles Trigger/Status/Fetch ---
+
+    async def profiles_trigger(
+        self,
+        url: Union[str, List[str]],
+        max_number_of_posts: Optional[int] = None,
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X profiles collection by URL (manual control)."""
+        url_list = [url] if isinstance(url, str) else url
+        payload = []
+        for u in url_list:
+            item: dict = {"url": u}
+            if max_number_of_posts is not None:
+                item["max_number_of_posts"] = max_number_of_posts
+            payload.append(item)
+
+        snapshot_id = await self.api_client.trigger(
+            payload=payload,
+            dataset_id=self.DATASET_ID_PROFILES,
+            limit_per_input=limit_per_input,
+        )
+        return ScrapeJob(
+            snapshot_id=snapshot_id,
+            api_client=self.api_client,
+            platform_name=self.PLATFORM_NAME,
+            cost_per_record=self.COST_PER_RECORD,
+        )
+
+    def profiles_trigger_sync(
+        self,
+        url: Union[str, List[str]],
+        max_number_of_posts: Optional[int] = None,
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X profiles collection by URL (sync)."""
+        return asyncio.run(
+            self.profiles_trigger(
+                url, max_number_of_posts=max_number_of_posts, limit_per_input=limit_per_input
+            )
+        )
+
+    async def profiles_status(self, snapshot_id: str) -> str:
+        """Check X profiles collection status."""
+        return await self._check_status_async(snapshot_id)
+
+    def profiles_status_sync(self, snapshot_id: str) -> str:
+        """Check X profiles collection status (sync)."""
+        return asyncio.run(self.profiles_status(snapshot_id))
+
+    async def profiles_fetch(self, snapshot_id: str) -> Any:
+        """Fetch X profiles results."""
+        return await self._fetch_results_async(snapshot_id)
+
+    def profiles_fetch_sync(self, snapshot_id: str) -> Any:
+        """Fetch X profiles results (sync)."""
+        return asyncio.run(self.profiles_fetch(snapshot_id))
+
+    # ============================================================================
+    # PROFILES - Discover by user name
+    # ============================================================================
+
+    async def profiles_by_username(
+        self,
+        user_name: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> Union[ScrapeResult, List[ScrapeResult]]:
+        """
+        Discover an X profile by handle / user name (async).
+
+        Args:
+            user_name: One handle or a list of handles, e.g. "elonmusk" (no URL).
+            limit_per_input: Optional cap on records collected per input.
+            timeout: Maximum wait time in seconds (default: 240)
+
+        Returns:
+            ScrapeResult or List[ScrapeResult] with profile data
+        """
+        is_single = isinstance(user_name, str)
+        name_list = [user_name] if is_single else user_name
+        payload = [{"user_name": n} for n in name_list]
+
+        sdk_function = get_caller_function_name()
+        result = await self.workflow_executor.execute(
+            payload=payload,
+            dataset_id=self.DATASET_ID_PROFILES,
+            poll_interval=DEFAULT_POLL_INTERVAL,
+            poll_timeout=timeout,
+            include_errors=True,
+            sdk_function=sdk_function,
+            normalize_func=self.normalize_result,
+            extra_params={"type": "discover_new", "discover_by": "user_name"},
+            limit_per_input=limit_per_input,
+        )
+
+        if is_single and isinstance(result.data, list) and len(result.data) == 1:
+            result.data = result.data[0]
+        return result
+
+    def profiles_by_username_sync(
+        self,
+        user_name: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+        timeout: int = DEFAULT_TIMEOUT_MEDIUM,
+    ) -> Union[ScrapeResult, List[ScrapeResult]]:
+        """Discover an X profile by handle / user name (sync)."""
+
+        async def _run():
+            async with self.engine:
+                return await self.profiles_by_username(
+                    user_name, limit_per_input=limit_per_input, timeout=timeout
+                )
+
+        return asyncio.run(_run())
+
+    # --- Discover-by-username Trigger/Status/Fetch ---
+
+    async def profiles_by_username_trigger(
+        self,
+        user_name: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X profile discovery by user name (manual control)."""
+        name_list = [user_name] if isinstance(user_name, str) else user_name
+        payload = [{"user_name": n} for n in name_list]
+
+        snapshot_id = await self.api_client.trigger(
+            payload=payload,
+            dataset_id=self.DATASET_ID_PROFILES,
+            extra_params={"type": "discover_new", "discover_by": "user_name"},
+            limit_per_input=limit_per_input,
+        )
+        return ScrapeJob(
+            snapshot_id=snapshot_id,
+            api_client=self.api_client,
+            platform_name=self.PLATFORM_NAME,
+            cost_per_record=self.COST_PER_RECORD,
+        )
+
+    def profiles_by_username_trigger_sync(
+        self,
+        user_name: Union[str, List[str]],
+        limit_per_input: Optional[int] = None,
+    ) -> ScrapeJob:
+        """Trigger X profile discovery by user name (sync)."""
+        return asyncio.run(
+            self.profiles_by_username_trigger(user_name, limit_per_input=limit_per_input)
+        )
+
+    async def profiles_by_username_status(self, snapshot_id: str) -> str:
+        """Check X profile-by-username discovery status."""
+        return await self._check_status_async(snapshot_id)
+
+    def profiles_by_username_status_sync(self, snapshot_id: str) -> str:
+        """Check X profile-by-username discovery status (sync)."""
+        return asyncio.run(self.profiles_by_username_status(snapshot_id))
+
+    async def profiles_by_username_fetch(self, snapshot_id: str) -> Any:
+        """Fetch X profile-by-username discovery results."""
+        return await self._fetch_results_async(snapshot_id)
+
+    def profiles_by_username_fetch_sync(self, snapshot_id: str) -> Any:
+        """Fetch X profile-by-username discovery results (sync)."""
+        return asyncio.run(self.profiles_by_username_fetch(snapshot_id))

--- a/src/brightdata/sync_client.py
+++ b/src/brightdata/sync_client.py
@@ -316,6 +316,7 @@ class SyncScrapeService:
         self._reddit = None
         self._perplexity = None
         self._digikey = None
+        self._x = None
 
     @property
     def amazon(self) -> "SyncAmazonScraper":
@@ -382,6 +383,12 @@ class SyncScrapeService:
         if self._digikey is None:
             self._digikey = SyncDigiKeyScraper(self._async.digikey, self._loop)
         return self._digikey
+
+    @property
+    def x(self) -> "SyncXScraper":
+        if self._x is None:
+            self._x = SyncXScraper(self._async.x, self._loop)
+        return self._x
 
 
 class SyncAmazonScraper:
@@ -871,6 +878,85 @@ class SyncDigiKeyScraper:
 
     def discover_by_category_fetch(self, snapshot_id):
         return self._loop.run_until_complete(self._async.discover_by_category_fetch(snapshot_id))
+
+
+class SyncXScraper:
+    """Sync wrapper for XScraper (X / Twitter)."""
+
+    def __init__(self, async_scraper, loop):
+        self._async = async_scraper
+        self._loop = loop
+
+    # Posts - collect by URL
+    def posts(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts(*args, **kwargs))
+
+    def posts_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_trigger(*args, **kwargs))
+
+    def posts_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_status(snapshot_id))
+
+    def posts_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_fetch(snapshot_id))
+
+    # Posts - discover by profile URL
+    def posts_by_profile(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_profile(*args, **kwargs))
+
+    def posts_by_profile_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_profile_trigger(*args, **kwargs))
+
+    def posts_by_profile_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_by_profile_status(snapshot_id))
+
+    def posts_by_profile_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_by_profile_fetch(snapshot_id))
+
+    # Posts - discover by profiles array
+    def posts_by_profiles_array(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.posts_by_profiles_array(*args, **kwargs))
+
+    def posts_by_profiles_array_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(
+            self._async.posts_by_profiles_array_trigger(*args, **kwargs)
+        )
+
+    def posts_by_profiles_array_status(self, snapshot_id):
+        return self._loop.run_until_complete(
+            self._async.posts_by_profiles_array_status(snapshot_id)
+        )
+
+    def posts_by_profiles_array_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.posts_by_profiles_array_fetch(snapshot_id))
+
+    # Profiles - collect by URL
+    def profiles(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles(*args, **kwargs))
+
+    def profiles_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles_trigger(*args, **kwargs))
+
+    def profiles_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_status(snapshot_id))
+
+    def profiles_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_fetch(snapshot_id))
+
+    # Profiles - discover by user name
+    def profiles_by_username(self, *args, **kwargs):
+        return self._loop.run_until_complete(self._async.profiles_by_username(*args, **kwargs))
+
+    def profiles_by_username_trigger(self, *args, **kwargs):
+        return self._loop.run_until_complete(
+            self._async.profiles_by_username_trigger(*args, **kwargs)
+        )
+
+    def profiles_by_username_status(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_by_username_status(snapshot_id))
+
+    def profiles_by_username_fetch(self, snapshot_id):
+        return self._loop.run_until_complete(self._async.profiles_by_username_fetch(snapshot_id))
 
 
 # ============================================================================

--- a/tests/unit/test_x_scraper.py
+++ b/tests/unit/test_x_scraper.py
@@ -1,0 +1,211 @@
+"""
+Tests for the X (Twitter) scraper — the 5 variants from devdocs/x/1.md.
+
+Asserts each variant sends the right dataset_id, payload shape, and discover
+params (type=discover_new & discover_by=...). Mocked at the api_client / workflow
+boundary — no network.
+"""
+
+import asyncio
+
+from unittest.mock import AsyncMock, MagicMock
+
+from brightdata.scrapers.x.scraper import XScraper
+from brightdata.scrapers.registry import get_scraper_for
+from brightdata.models import ScrapeResult
+from brightdata.sync_client import SyncXScraper
+
+POSTS = "gd_lwxkxvnf1cynvib9co"
+PROFILES = "gd_lwxmeb2u1cniijd7t4"
+
+
+def _scraper() -> XScraper:
+    s = XScraper(bearer_token="x" * 12, engine=MagicMock())
+    s.api_client = MagicMock()
+    s.api_client.trigger = AsyncMock(return_value="snap1")
+    return s
+
+
+def _trigger_kwargs(s: XScraper) -> dict:
+    return s.api_client.trigger.await_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Per-variant trigger payload / dataset / discover params
+# ---------------------------------------------------------------------------
+
+
+class TestXTriggerPayloads:
+    async def test_v1_posts_by_url(self):
+        s = _scraper()
+        await s.posts_trigger("https://x.com/CNN/status/1796673270344810776")
+        kw = _trigger_kwargs(s)
+        assert kw["dataset_id"] == POSTS
+        assert kw["payload"] == [{"url": "https://x.com/CNN/status/1796673270344810776"}]
+        assert "extra_params" not in kw  # plain collect, no discover
+
+    async def test_v2_posts_by_profile(self):
+        s = _scraper()
+        await s.posts_by_profile_trigger(
+            "https://x.com/elonmusk", start_date="2023-01-15", end_date="2024-03-15"
+        )
+        kw = _trigger_kwargs(s)
+        assert kw["dataset_id"] == POSTS
+        assert kw["payload"] == [
+            {
+                "url": "https://x.com/elonmusk",
+                "start_date": "2023-01-15",
+                "end_date": "2024-03-15",
+            }
+        ]
+        assert kw["extra_params"] == {"type": "discover_new", "discover_by": "profile_url"}
+
+    async def test_v2_dates_default_to_empty_string(self):
+        s = _scraper()
+        await s.posts_by_profile_trigger("https://x.com/fabrizioromano")
+        payload = _trigger_kwargs(s)["payload"]
+        assert payload[0]["start_date"] == ""
+        assert payload[0]["end_date"] == ""
+
+    async def test_v3_posts_by_profiles_array(self):
+        s = _scraper()
+        urls = ["https://x.com/NextLifeAdFlow", "https://x.com/BSCNews"]
+        await s.posts_by_profiles_array_trigger(urls)
+        kw = _trigger_kwargs(s)
+        assert kw["dataset_id"] == POSTS
+        # one input row carrying the whole array
+        assert kw["payload"] == [{"urls": urls, "start_date": "", "end_date": ""}]
+        assert kw["extra_params"] == {"type": "discover_new", "discover_by": "profiles_array"}
+
+    async def test_v4_profiles_by_url(self):
+        s = _scraper()
+        await s.profiles_trigger("https://x.com/elonmusk", max_number_of_posts=100)
+        kw = _trigger_kwargs(s)
+        assert kw["dataset_id"] == PROFILES
+        assert kw["payload"] == [{"url": "https://x.com/elonmusk", "max_number_of_posts": 100}]
+        assert "extra_params" not in kw
+
+    async def test_v4_profiles_omits_max_when_none(self):
+        s = _scraper()
+        await s.profiles_trigger("https://x.com/cnn")
+        assert _trigger_kwargs(s)["payload"] == [{"url": "https://x.com/cnn"}]
+
+    async def test_v5_profiles_by_username(self):
+        s = _scraper()
+        await s.profiles_by_username_trigger(["elonmusk", "BillGates"])
+        kw = _trigger_kwargs(s)
+        assert kw["dataset_id"] == PROFILES
+        assert kw["payload"] == [{"user_name": "elonmusk"}, {"user_name": "BillGates"}]
+        assert kw["extra_params"] == {"type": "discover_new", "discover_by": "user_name"}
+
+
+# ---------------------------------------------------------------------------
+# Full path (execute) — dataset + payload threaded correctly
+# ---------------------------------------------------------------------------
+
+
+class TestXFullPath:
+    async def test_posts_uses_posts_dataset_and_unwraps_single(self):
+        s = _scraper()
+        s.workflow_executor.execute = AsyncMock(
+            return_value=ScrapeResult(success=True, data=[{"id": 1}])
+        )
+        res = await s.posts("https://x.com/CNN/status/1796673270344810776")
+        kw = s.workflow_executor.execute.await_args.kwargs
+        assert kw["dataset_id"] == POSTS
+        assert kw["payload"] == [{"url": "https://x.com/CNN/status/1796673270344810776"}]
+        assert "extra_params" not in kw
+        assert res.success and res.data == {"id": 1}  # single URL unwrapped
+
+    async def test_profiles_by_username_full_path_discover(self):
+        s = _scraper()
+        s.workflow_executor.execute = AsyncMock(
+            return_value=ScrapeResult(success=True, data=[{"u": 1}])
+        )
+        await s.profiles_by_username("elonmusk")
+        kw = s.workflow_executor.execute.await_args.kwargs
+        assert kw["dataset_id"] == PROFILES
+        assert kw["payload"] == [{"user_name": "elonmusk"}]
+        assert kw["extra_params"] == {"type": "discover_new", "discover_by": "user_name"}
+
+
+# ---------------------------------------------------------------------------
+# Wiring: registry + sync wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestXWiring:
+    def test_registered_for_x_domain(self):
+        assert get_scraper_for("https://x.com/elonmusk") is XScraper
+
+    def test_sync_wrapper_delegates(self):
+        loop = asyncio.new_event_loop()
+        try:
+            api = MagicMock()
+            api.posts = AsyncMock(return_value=ScrapeResult(success=True, data=[{"p": 1}]))
+            api.profiles_by_username = AsyncMock(return_value=ScrapeResult(success=True, data=[]))
+            s = SyncXScraper(api, loop)
+            assert s.posts("https://x.com/u/status/1").data == [{"p": 1}]
+            api.posts.assert_awaited_once()
+            s.profiles_by_username("elonmusk")
+            api.profiles_by_username.assert_awaited_once()
+        finally:
+            loop.close()
+
+
+class _FakeTriggerResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self):
+        return {"snapshot_id": "s1"}
+
+
+class TestXLimitPerInput:
+    async def test_forwarded_on_discover_trigger(self):
+        s = _scraper()
+        await s.posts_by_profile_trigger("https://x.com/elonmusk", limit_per_input=2)
+        assert _trigger_kwargs(s)["limit_per_input"] == 2
+
+    async def test_forwarded_on_collect_trigger(self):
+        s = _scraper()
+        await s.posts_trigger("https://x.com/u/status/1", limit_per_input=5)
+        assert _trigger_kwargs(s)["limit_per_input"] == 5
+
+    async def test_none_by_default(self):
+        s = _scraper()
+        await s.profiles_by_username_trigger("elonmusk")
+        assert _trigger_kwargs(s).get("limit_per_input") is None
+
+
+class TestTriggerBodyWrapping:
+    """api_client.trigger sends a bare array by default, wrapped body with a limit."""
+
+    def _client_capturing(self, captured):
+        from brightdata.scrapers.api_client import DatasetAPIClient
+
+        engine = MagicMock()
+
+        def post_to_url(url, json_data=None, params=None):
+            captured["body"] = json_data
+            return _FakeTriggerResponse()
+
+        engine.post_to_url = post_to_url
+        return DatasetAPIClient(engine)
+
+    async def test_bare_array_without_limit(self):
+        captured = {}
+        c = self._client_capturing(captured)
+        await c.trigger(payload=[{"url": "u"}], dataset_id="d")
+        assert captured["body"] == [{"url": "u"}]
+
+    async def test_wrapped_with_limit(self):
+        captured = {}
+        c = self._client_capturing(captured)
+        await c.trigger(payload=[{"url": "u"}], dataset_id="d", limit_per_input=2)
+        assert captured["body"] == {"input": [{"url": "u"}], "limit_per_input": 2}


### PR DESCRIPTION
Adds the X (Twitter) Web Scraper (`client.scrape.x`) — previously missing from the SDK.

  - 5 variants: `posts`, `posts_by_profile`, `posts_by_profiles_array`, `profiles`, `profiles_by_username` (collect-by-URL and discover), each with async/sync + trigger/status/fetch.
  - Adds `limit_per_input` to cap records per input (additive — other scrapers unchanged).
  - Sync parity, tests, and a notebook walkthrough. 
  - Version → 2.4.1.